### PR TITLE
time(1) comes from time.h

### DIFF
--- a/parma/diffMC/parma_shapeTargets.cc
+++ b/parma/diffMC/parma_shapeTargets.cc
@@ -1,3 +1,4 @@
+#include <time.h>
 #include <PCU.h>
 #include "parma_sides.h"
 #include "parma_weights.h"


### PR DESCRIPTION
This will fix compilation with the latest PGI compilers, though some of the tests will still fail non-deterministically (the failures usually happen during migration)
