### PR TITLE
Enabled editing of matricies after construction

### DIFF
--- a/apf/apfMatrix.h
+++ b/apf/apfMatrix.h
@@ -40,6 +40,18 @@ class Matrix : public Array<Vector<N>,M>
       for (std::size_t j=0; j < N; ++j)
         this->elements[i][j] = array[i][j];
     }
+
+    /** \brief immutable index operator */
+    double operator()(std::size_t i, std::size_t j) const
+    {
+      return this->elements[i][j];
+    }
+    /** \brief mutable index operator */
+    double& operator()(std::size_t i, std::size_t j)
+    {
+      return this->elements[i][j];
+    }
+
     /** \brief add two matrices */
     Matrix<M,N> operator+(Matrix<M,N> const& b) const
     {


### PR DESCRIPTION
previously one could not edit the contents of an apf::Matrix after it had been constructed.
this was annoying when trying to allocate an array of apf::Matrix and having the default constructor called for every matrix. Now you can actually use the matrix in the array.