### PR TITLE
add equality operator for apf::Matrix

### DIFF
--- a/apf/apf.h
+++ b/apf/apf.h
@@ -411,8 +411,13 @@ class Integrator
     /** \brief Construct an Integrator given an order of accuracy. */
     Integrator(int o);
     virtual ~Integrator();
-    /** \brief Run the Integrator over the local Mesh. */
-    void process(Mesh* m);
+    /** \brief Run the Integrator over the local Mesh.
+     * \param m mesh to integrate over
+     * \param dim optional dimension to integrate over. This defaults to
+     * integration over the mesh dimesion which may not be correct e.g. in the case
+     * of a 1D element embeded in 3D space.
+     * */
+    void process(Mesh* m, int dim=-1);
     /** \brief Run the Integrator over a Mesh Element. */
     void process(MeshElement* e);
     /** \brief User callback: element entry.

--- a/apf/apfIntegrate.cc
+++ b/apf/apfIntegrate.cc
@@ -8,6 +8,7 @@
 #include "apfIntegrate.h"
 #include "apfMesh.h"
 #include "apf.h"
+#include "pcu_util.h"
 
 namespace apf {
 
@@ -640,9 +641,11 @@ void Integrator::parallelReduce()
 {
 }
 
-void Integrator::process(Mesh* m)
+void Integrator::process(Mesh* m, int d)
 {
-  int d = m->getDimension();
+  if(d<0)
+    d = m->getDimension();
+  PCU_DEBUG_ASSERT(d<=m->getDimension());
   MeshEntity* entity;
   MeshIterator* elements = m->begin(d);
   while ((entity = m->iterate(elements)))


### PR DESCRIPTION
This functionality is needed for writing some unit tests. It uses
floating point arithmetic to find a close value. The isClose function
came from Knuth art of computer programming.

closes PR #144 since made the PR from the wrong base branch