### PR TITLE
fix enum for compile with gcc/4.9.2

### DIFF
--- a/apf/apfConvert.cc
+++ b/apf/apfConvert.cc
@@ -8,6 +8,7 @@
 #include <map>
 #include <pcu_util.h>
 #include <iostream>
+#include <cstdlib>
 
 namespace apf {
 
@@ -231,17 +232,17 @@ class Converter
             int* intData;
             long* lngData; 
             switch (tagType) {
-              case apf::Mesh::TagType::DOUBLE:
+              case apf::Mesh::DOUBLE:
                 dblData = new double[tagSize];
                 inMesh->getDoubleTag(e, in, dblData);
                 outMesh->setDoubleTag(newFromOld[e], out, dblData);
                 break;
-              case apf::Mesh::TagType::INT:
+              case apf::Mesh::INT:
                 intData = new int[tagSize];
                 inMesh->getIntTag(e, in, intData);
                 outMesh->setIntTag(newFromOld[e], out, intData);
                 break;
-              case apf::Mesh::TagType::LONG:
+              case apf::Mesh::LONG:
                 lngData = new long[tagSize];
                 inMesh->getLongTag(e, in, lngData);
                 outMesh->setLongTag(newFromOld[e], out, lngData);
@@ -319,13 +320,13 @@ class Converter
         if (!outMesh->findTag(tagName)) {
           apf::MeshTag* out = NULL;
           switch (tagType) {
-            case apf::Mesh::TagType::DOUBLE:
+            case apf::Mesh::DOUBLE:
               out = outMesh->createDoubleTag(tagName, tagSize);
               break;
-            case apf::Mesh::TagType::INT:
+            case apf::Mesh::INT:
               out = outMesh->createIntTag(tagName, tagSize);
               break;
-            case apf::Mesh::TagType::LONG:
+            case apf::Mesh::LONG:
               out = outMesh->createLongTag(tagName, tagSize);
               break;
             default:

--- a/test/verify_convert.cc
+++ b/test/verify_convert.cc
@@ -24,7 +24,7 @@ apf::Mesh2* createMesh()
       m->createVertex(NULL, apf::Vector3(0, 0, 0), apf::Vector3(0, 0, 0));
   verts[1] =
       m->createVertex(NULL, apf::Vector3(1, 0, 0), apf::Vector3(1, 0, 0));
-  m->createEntity(apf::Mesh::Type::EDGE, NULL, verts);
+  m->createEntity(apf::Mesh::EDGE, NULL, verts);
   return m;
 }
 class twox : public apf::Function {


### PR DESCRIPTION
GCC 4.9.2 does not have scoped enums, so in order to compile changes to
apfConvert.cc the TagType scope needed to be removed.

This should fix an issue that was brought to my attention about pull #163.