### PR TITLE
make apf Integrator process functions virtual

### DIFF
--- a/apf/apf.h
+++ b/apf/apf.h
@@ -369,9 +369,9 @@ class Integrator
     Integrator(int o);
     virtual ~Integrator();
     /** \brief Run the Integrator over the local Mesh. */
-    void process(Mesh* m);
+    virtual void process(Mesh* m);
     /** \brief Run the Integrator over a Mesh Element. */
-    void process(MeshElement* e);
+    virtual void process(MeshElement* e);
     /** \brief User callback: element entry.
       *
       * \details APF will call this function every time the


### PR DESCRIPTION
for testing in tobinw/biotissue I want to override the process functions, so I can introspect intermediate steps. e.g. printing the elemental stiffness matrices.