### PR TITLE
control print statment output

### DIFF
--- a/apf/apf.cc
+++ b/apf/apf.cc
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 namespace apf {
 
@@ -353,7 +354,7 @@ double computeCosAngle(Mesh* m, MeshEntity* pe, MeshEntity* e1, MeshEntity* e2,
 
     cosAngle = computeCosAngleInTri(m, pe, e1, e2, Q);
   } else {
-    printf("The requested angle computation is not implemented. Aborting! \n");
+    lion_oprint(1,"The requested angle computation is not implemented. Aborting! \n");
     abort();
   }
   return cosAngle;
@@ -439,7 +440,7 @@ void sharedReduction(Field* f, Sharing* shr, bool delete_shr,
 
 void fail(const char* why)
 {
-  fprintf(stderr,"APF FAILED: %s\n",why);
+  lion_eprint(1,"APF FAILED: %s\n",why);
   abort();
 }
 

--- a/apf/apfConvert.cc
+++ b/apf/apfConvert.cc
@@ -7,6 +7,7 @@
 #include "apfNumbering.h"
 #include <map>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <iostream>
 #include <cstdlib>
 
@@ -247,7 +248,7 @@ class Converter
                 outMesh->setLongTag(newFromOld[e], out, lngData);
                 break;
               default:
-                std::cerr << "Tried to convert unknown tag type\n";
+                lion_eprint(1,"Tried to convert unknown tag type\n");
                 abort();
                 break;
             }
@@ -329,7 +330,7 @@ class Converter
               out = outMesh->createLongTag(tagName, tagSize);
               break;
             default:
-              std::cerr << "Tried to convert unknown tag type\n";
+              lion_eprint(1,"Tried to convert unknown tag type\n");
               abort();
           }
           PCU_DEBUG_ASSERT(out);
@@ -343,7 +344,7 @@ class Converter
       if (inMesh->getShape() != getLagrange(2) && inMesh->getShape() != getSerendipity())
         return;
       if ( ! PCU_Comm_Self())
-        fprintf(stderr,"transferring quadratic mesh\n");
+        lion_eprint(1,"transferring quadratic mesh\n");
       changeMeshShape(outMesh,inMesh->getShape(),/*project=*/false);
       convertField(inMesh->getCoordinateField(),outMesh->getCoordinateField());
     }

--- a/apf/apfMIS.cc
+++ b/apf/apfMIS.cc
@@ -2,6 +2,7 @@
 #include <cstdlib>
 #include "apfMIS.h"
 #include "apf.h"
+#include <lionPrint.h>
 #include <stdio.h>
 namespace apf {    
   MIS::MIS(Mesh* mesh, int vtx_dim_, int edge_dim_)
@@ -12,7 +13,7 @@ namespace apf {
   MIS* initializeMIS(Mesh* mesh, int vtx_dim, int edge_dim) {
     MeshTag* coloring = mesh->findTag("coloring");
     if (coloring!=NULL) {
-      printf("[ERROR] Only one MIS can exist at a time.\n");
+      lion_oprint(1,"[ERROR] Only one MIS can exist at a time.\n");
       return NULL;
     }
     MIS* mis = new MIS(mesh,vtx_dim,edge_dim);

--- a/apf/apfMesh.cc
+++ b/apf/apfMesh.cc
@@ -13,6 +13,7 @@
 #include "apfTagData.h"
 #include <gmi.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <algorithm>
 
 namespace apf {
@@ -817,11 +818,11 @@ void printTypes(Mesh* m)
   m->end(it);
   PCU_Add_Longs(typeCnt,Mesh::TYPES);
   if (!PCU_Comm_Self()) {
-    printf("number of");
+    lion_oprint(1,"number of");
     for (int i=0; i<Mesh::TYPES; i++)
       if (dim == Mesh::typeDimension[i])
-        printf(" %s %ld", Mesh::typeName[i], typeCnt[i]);
-    printf("\n");
+        lion_oprint(1," %s %ld", Mesh::typeName[i], typeCnt[i]);
+    lion_oprint(1,"\n");
   }
 }
 
@@ -833,7 +834,7 @@ void printStats(Mesh* m)
   PCU_Add_Longs(n, 4);
   printTypes(m);
   if (!PCU_Comm_Self())
-    printf("mesh entity counts: v %ld e %ld f %ld r %ld\n",
+    lion_oprint(1,"mesh entity counts: v %ld e %ld f %ld r %ld\n",
         n[0], n[1], n[2], n[3]);
 }
 
@@ -844,7 +845,7 @@ void warnAboutEmptyParts(Mesh* m)
     ++emptyParts;
   emptyParts = PCU_Add_Int(emptyParts);
   if (emptyParts && (!PCU_Comm_Self()))
-    fprintf(stderr,"APF warning: %d empty parts\n",emptyParts);
+    lion_eprint(1,"APF warning: %d empty parts\n",emptyParts);
 }
 
 static void getRemotesArray(Mesh* m, MeshEntity* e, CopyArray& a)

--- a/apf/apfMigrate.cc
+++ b/apf/apfMigrate.cc
@@ -10,6 +10,7 @@
 #include "apfCavityOp.h"
 #include "apf.h"
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 namespace apf {
@@ -861,7 +862,7 @@ void setMigrationLimit(size_t maxElements)
 {
   if( maxElements >= maxMigrationLimit ) {
     if(!PCU_Comm_Self())
-      fprintf(stderr, "ERROR requested migration limit exceeds"
+      lion_eprint(1, "ERROR requested migration limit exceeds"
                       " %lu... exiting\n", maxMigrationLimit);
     abort();
   }

--- a/apf/apfVerify.cc
+++ b/apf/apfVerify.cc
@@ -5,6 +5,7 @@
 #include <sstream>
 #include <apfGeometry.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include "stdlib.h" // malloc
 
 namespace apf {
@@ -177,7 +178,7 @@ static void verifyUp(Mesh* m, UpwardCounts& guc,
       << upwardCount << " upward adjacencies\n";
     // use a stringstream to prevent output from different procs mixing
     std::string s = ss.str();
-    fprintf(stderr,"%s",s.c_str());
+    lion_eprint(1,"%s",s.c_str());
   }
 }
 
@@ -473,7 +474,7 @@ long verifyVolumes(Mesh* m, bool printVolumes)
         ss << "warning: element volume " << v
           << " at " << getLinearCentroid(m, e) << '\n';
         std::string s = ss.str();
-        fprintf(stdout, "%s", s.c_str());
+        lion_oprint(1, "%s", s.c_str());
         fflush(stdout);
       }
       ++n;
@@ -724,7 +725,7 @@ static void receiveTagData(Mesh* m, DynamicArray<MeshTag*>& tags)
   int global_size = PCU_Max_Int((int)mismatch_tags.size());
   if (global_size&&!PCU_Comm_Self())
     for (std::set<MeshTag*>::iterator it=mismatch_tags.begin(); it!=mismatch_tags.end(); ++it)
-      printf("  - tag \"%s\" data mismatch over remote/ghost copies\n", m->getTagName(*it));
+      lion_oprint(1,"  - tag \"%s\" data mismatch over remote/ghost copies\n", m->getTagName(*it));
 }
 
 static void verifyTags(Mesh* m)
@@ -745,13 +746,13 @@ static void verifyTags(Mesh* m)
   {
     if (n)
     {
-      printf("  - verifying tags: ");
+      lion_oprint(1,"  - verifying tags: ");
       for (int i = 0; i < n; ++i)
       {
-        printf("%s", m->getTagName(tags[i]));
-        if (i<n-1) printf(", ");      
+        lion_oprint(1,"%s", m->getTagName(tags[i]));
+        if (i<n-1) lion_oprint(1,", ");
       }
-      printf("\n");
+      lion_oprint(1,"\n");
     }
   }
   PCU_Comm_Send();
@@ -831,13 +832,13 @@ void verify(Mesh* m, bool abort_on_error)
   verifyMatches(m);
   long n = verifyCoords(m);
   if (n && (!PCU_Comm_Self()))
-    fprintf(stderr,"apf::verify fail: %ld coordinate mismatches\n", n);
+    lion_eprint(1,"apf::verify fail: %ld coordinate mismatches\n", n);
   n = verifyVolumes(m);
   if (n && (!PCU_Comm_Self()))
-    fprintf(stderr,"apf::verify warning: %ld negative simplex elements\n", n);
+    lion_eprint(1,"apf::verify warning: %ld negative simplex elements\n", n);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("mesh verified in %f seconds\n", t1 - t0);
+    lion_oprint(1,"mesh verified in %f seconds\n", t1 - t0);
 }
 
 }

--- a/apf/apfVtk.cc
+++ b/apf/apfVtk.cc
@@ -16,6 +16,7 @@
 #include <sstream>
 #include <fstream>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <stdint.h>
 #include <vector>
@@ -896,7 +897,7 @@ static void writeVtuFile(const char* prefix,
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
   {
-    printf("writeVtuFile into buffers: %f seconds\n", t1 - t0);
+    lion_oprint(1,"writeVtuFile into buffers: %f seconds\n", t1 - t0);
   }
   { //block forces std::ofstream destructor call
     std::ofstream file(fileNameAndPath.c_str());
@@ -906,7 +907,7 @@ static void writeVtuFile(const char* prefix,
   double t2 = PCU_Time();
   if (!PCU_Comm_Self())
   {
-    printf("writeVtuFile buffers to disk: %f seconds\n", t2 - t1);
+    lion_oprint(1,"writeVtuFile buffers to disk: %f seconds\n", t2 - t1);
   }
 }
 
@@ -961,7 +962,7 @@ void writeVtkFilesRunner(const char* prefix,
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
   {
-    printf("vtk files %s written in %f seconds\n", prefix, t1 - t0);
+    lion_oprint(1,"vtk files %s written in %f seconds\n", prefix, t1 - t0);
   }
   delete n;
 }

--- a/crv/crv.cc
+++ b/crv/crv.cc
@@ -9,6 +9,7 @@
 #include "crvBezier.h"
 #include "crvTables.h"
 #include "crvQuality.h"
+#include <lionPrint.h>
 #include <cstdlib>
 
 namespace crv {
@@ -174,7 +175,7 @@ int countNumberInvalidElements(apf::Mesh2* m)
 
 void fail(const char* why)
 {
-  fprintf(stderr,"CRV FAILED: %s\n",why);
+  lion_eprint(1,"CRV FAILED: %s\n",why);
   abort();
 }
 

--- a/crv/crvShape.cc
+++ b/crv/crvShape.cc
@@ -6,6 +6,7 @@
  */
 
 #include <PCU.h>
+#include <lionPrint.h>
 #include "crv.h"
 #include "crvAdapt.h"
 #include "crvShape.h"
@@ -666,13 +667,13 @@ void fixCrvElementShapes(Adapt* a)
     /* int numOpSuccess = fixLargeAngles(a); // update this */
     /* PCU_Add_Ints(&numOpSuccess,1); */
     /* if (PCU_Comm_Self() == 0) */
-    /*   printf("==> %d large angle fix operations succeeded.\n", numOpSuccess); */
+    /*   lion_oprint(1,"==> %d large angle fix operations succeeded.\n", numOpSuccess); */
     markCrvBadQuality(a);
     fixShortEdgeElements(a); // update this
     /* int numEdgeRemoved = fixShortEdgeElements(a); // update this */
     /* PCU_Add_Ints(&numEdgeRemoved,1); */
     /* if (PCU_Comm_Self() == 0) */
-    /*   printf("==> %d edges removal operations succeeded.\n", numEdgeRemoved); */
+    /*   lion_oprint(1,"==> %d edges removal operations succeeded.\n", numEdgeRemoved); */
     count = markCrvBadQuality(a);
     ++i;
   } while(count < prev_count && i < 6); // the second conditions is to make sure this does not take long

--- a/crv/crvVtk.cc
+++ b/crv/crvVtk.cc
@@ -13,6 +13,7 @@
 #include <sstream>
 #include <fstream>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 // === includes for safe_mkdir ===
 #include <reel.h>
@@ -371,7 +372,7 @@ static void writeTriJacobianDet(std::ostream& file, apf::Mesh* m, int n)
           ss << "warning: Tri Jacobian Determinant is negative,  " << detJ[j]
               << '\n';
           std::string s = ss.str();
-          fprintf(stderr, "%s", s.c_str());
+          lion_eprint(1, "%s", s.c_str());
           isValid = false;
         }
         maxJ = std::max(detJ[count],maxJ);
@@ -451,7 +452,7 @@ static void writeTetJacobianDet(std::ostream& file, apf::Mesh* m, int n)
               ss << "warning: Tet Jacobian Determinant is negative,  "
                  << detJ[count] << '\n';
               std::string s = ss.str();
-              fprintf(stderr, "%s", s.c_str());
+              lion_eprint(1, "%s", s.c_str());
               isValid = false;
             }
             maxJ = std::max(detJ[count],maxJ);
@@ -536,7 +537,7 @@ static void writeMinTetJacobianDet(std::ostream& file, apf::Mesh* m, int n)
               ss << "warning: Tet Jacobian Determinant is negative,  "
                  << detJ[count] << '\n';
               std::string s = ss.str();
-              fprintf(stderr, "%s", s.c_str());
+              lion_eprint(1, "%s", s.c_str());
               isValid = false;
             }
             maxJ = std::max(detJ[count],maxJ);
@@ -1089,7 +1090,7 @@ void writeCurvedVtuFiles(apf::Mesh* m, int type, int n, const char* prefix)
   PCU_Barrier();
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("%s vtk files %s written in %f seconds\n",
+    lion_oprint(1,"%s vtk files %s written in %f seconds\n",
         apf::Mesh::typeName[type],getPvtuDirectoryStr(prefix, type, n).c_str(),t1 - t0);
 }
 

--- a/gmi/CMakeLists.txt
+++ b/gmi/CMakeLists.txt
@@ -28,7 +28,7 @@ set(HEADERS
 
 # Add the gmi library
 add_library(gmi ${SOURCES})
-target_link_libraries(gmi pcu)
+target_link_libraries(gmi pcu lion)
 target_include_directories(gmi INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>

--- a/gmi/gmi.c
+++ b/gmi/gmi.c
@@ -8,6 +8,7 @@
 
 *******************************************************************************/
 #include "gmi.h"
+#include <lionPrint.h>
 #include <stdlib.h>
 #include <string.h>
 #include <pcu_util.h>
@@ -216,7 +217,7 @@ struct gmi_model* gmi_load(const char* filename)
 
 void gmi_fail(const char* why)
 {
-  fprintf(stderr,"gmi failed: %s\n",why);
+  lion_eprint(1,"gmi failed: %s\n",why);
   abort();
 }
 

--- a/lion/CMakeLists.txt
+++ b/lion/CMakeLists.txt
@@ -8,7 +8,7 @@ if (LION_COMPRESS)
 endif()
 
 # Package sources
-set(SOURCES lionBase64.cc)
+set(SOURCES lionBase64.cc lionPrint.c)
 if(LION_COMPRESS)
   set(SOURCES ${SOURCES} lionZLib.cc)
 else()
@@ -19,6 +19,7 @@ endif()
 set(HEADERS
   lionBase64.h
   lionCompress.h
+  lionPrint.h
 )
 
 # Add the lion Library

--- a/lion/lionPrint.c
+++ b/lion/lionPrint.c
@@ -1,0 +1,71 @@
+#include "lionPrint.h"
+#include <assert.h>
+#include <stdarg.h>
+
+int lion_verbosity_level = 0;
+FILE* lion_stdout = NULL;
+FILE* lion_stderr = NULL;
+
+int lion_get_verbosity() {
+  return lion_verbosity_level;
+}
+
+void lion_set_verbosity(int lvl) {
+  assert(lvl >= 0);
+  lion_verbosity_level = lvl;
+}
+
+void lion_set_stdout(FILE* out) {
+  assert(out != NULL);
+  lion_stdout = out;
+}
+
+void lion_set_stderr(FILE* err) {
+  assert(err != NULL);
+  lion_stderr = err;
+}
+
+#define print(lvl,dest,fmt) \
+  va_list ap; \
+  va_start(ap,fmt); \
+  int written = 0; \
+  if(lion_verbosity_level >= lvl) \
+    written = vfprintf(dest,fmt,ap); \
+  va_end(ap); \
+  return written;
+
+#define setstream(stream,defaultStream) \
+  static int calls = 0; \
+  if( !calls && !stream) \
+    stream = defaultStream; \
+  calls++; \
+
+int lion_oprint(int lvl, char const* fmt, ...) {
+  setstream(lion_stdout,stdout);
+  assert(lvl >= 0);
+  print(lvl,lion_stdout,fmt);
+}
+
+int lion_eprint(int lvl, char const* fmt, ...) {
+  setstream(lion_stderr,stderr);
+  assert(lvl >= 0);
+  print(lvl,lion_stderr,fmt);
+}
+
+#define vprint(lvl,dest,fmt,ap) \
+  int written = 0; \
+  if(lion_verbosity_level >= lvl) \
+    written = vfprintf(dest,fmt,ap); \
+  return written;
+
+int lion_voprint(int lvl, char const* fmt, va_list ap) {
+  setstream(lion_stdout,stdout);
+  assert(lvl >= 0);
+  vprint(lvl,lion_stdout,fmt,ap);
+}
+
+int lion_veprint(int lvl, char const* fmt, va_list ap) {
+  setstream(lion_stderr,stderr);
+  assert(lvl >= 0);
+  vprint(lvl,lion_stderr,fmt,ap);
+}

--- a/lion/lionPrint.h
+++ b/lion/lionPrint.h
@@ -1,0 +1,63 @@
+#ifndef LION_PRINT_H
+#define LION_PRINT_H
+#include <stdio.h>
+#include <stdarg.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * \brief set the verbosity of output
+ * \param lvl (in) 0 = off, increasing values (> 0) increase the amount of output
+ */
+void lion_set_verbosity(int lvl);
+
+/**
+ * \brief get the verbosity level for output
+ */
+int lion_get_verbosity();
+
+/**
+ * \brief set the stdout file stream destination
+ * \param out (in) the file stream written to by lion_oprint
+ */
+void lion_set_stdout(FILE* out);
+
+/**
+ * \brief set the stderr file stream destination
+ * \param err (in) the file stream written to by lion_eprint
+ */
+void lion_set_stderr(FILE* err);
+
+/**
+ * \brief fprintf(stdout,...) wrapper
+ * \param lvl (in) the verbosity level of this message
+ * \remark see printf for arguments
+ */
+int lion_oprint(int lvl, char const*, ...);
+
+/**
+ * \brief fprintf(stderr,...) wrapper
+ * \param lvl (in) the verbosity level of this message
+ * \remark see printf for arguments
+ */
+int lion_eprint(int lvl, char const*, ...);
+
+/**
+ * \brief variadic fprintf(stdout,...) wrapper
+ * \param lvl (in) the verbosity level of this message
+ * \remark see printf for arguments, used for nesting within variadic functions
+ */
+int lion_voprint(int lvl, char const*, va_list);
+
+/**
+ * \brief variadic fprintf(stderr,...) wrapper
+ * \param lvl (in) the verbosity level of this message
+ * \remark see printf for arguments, used for nesting within variadic functions
+ */
+int lion_veprint(int lvl, char const*, va_list);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // header guard

--- a/ma/maAdapt.cc
+++ b/ma/maAdapt.cc
@@ -8,6 +8,7 @@
  
 *******************************************************************************/
 #include <PCU.h>
+#include <lionPrint.h>
 #include "maAdapt.h"
 #include "maInput.h"
 #include "maTables.h"
@@ -463,12 +464,12 @@ void print(const char* format, ...)
 {
   if (PCU_Comm_Self())
     return;
-  printf("\nMeshAdapt: ");
+  lion_oprint(1,"\nMeshAdapt: ");
   va_list ap;
   va_start(ap,format);
-  vfprintf(stdout,format,ap);
+  lion_voprint(1,format,ap);
   va_end(ap);
-  printf("\n");
+  lion_oprint(1,"\n");
 }
 
 void setFlagOnClosure(Adapt* a, Entity* element, int flag)

--- a/ma/maInput.cc
+++ b/ma/maInput.cc
@@ -8,6 +8,7 @@
  
 *******************************************************************************/
 #include "maInput.h"
+#include <lionPrint.h>
 #include <apfShape.h>
 #include <cstdio>
 #include <pcu_util.h>
@@ -71,8 +72,8 @@ void setDefaultValues(Input* in)
 
 void rejectInput(const char* str)
 {
-  fprintf(stderr,"MeshAdapt input error:\n");
-  fprintf(stderr,"%s\n",str);
+  lion_eprint(1,"MeshAdapt input error:\n");
+  lion_eprint(1,"%s\n",str);
   abort();
 }
 

--- a/ma/maLayer.cc
+++ b/ma/maLayer.cc
@@ -5,6 +5,7 @@
 #include "maShape.h"
 #include <sstream>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 namespace ma {
 
@@ -165,7 +166,7 @@ void checkLayerShape(Mesh* m, const char* key)
            << " at " << apf::getLinearCentroid(m, e)
            << " is unsafe to tetrahedronize\n";
         std::string s = ss.str();
-        fprintf(stdout,"%s",s.c_str());
+        lion_oprint(1,"%s",s.c_str());
         fflush(stdout);
         ++n;
       }

--- a/ma/maLayerTemplates.cc
+++ b/ma/maLayerTemplates.cc
@@ -8,6 +8,7 @@
 #include <cstdio>
 #include <sstream>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 namespace ma {
 
@@ -96,15 +97,15 @@ void splitPrism_0(Refine* r, Entity* p, Entity** v)
     ss << "this should only be done to accomodate unsafe elements.\n";
     ss << "the new vertex position will be optimized.\n";
     std::string s = ss.str();
-    fprintf(stderr, "%s", s.c_str());
+    lion_eprint(1, "%s", s.c_str());
     Vector xi(1./3.,1./3.,0);
     apf::MeshElement* me = apf::createMeshElement(m, p);
     Entity* vert = prismToTetsBadCase(r, p, v, code, point);
     bool success = ma::repositionVertex(m, vert, 200, 0.05);
     if (success)
-      fprintf(stderr, "repositioning succeeded\n");
+      lion_eprint(1, "repositioning succeeded\n");
     else
-      fprintf(stderr, "repositioning failed\n");
+      lion_eprint(1, "repositioning failed\n");
     a->solutionTransfer->onVertex(me, xi, vert);
     a->sizeField->interpolate(me, xi, vert);
     apf::destroyMeshElement(me);

--- a/ma/maSnap.cc
+++ b/ma/maSnap.cc
@@ -18,6 +18,7 @@
 #include "maDBG.h"
 #include <apfGeometry.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <iostream>
 #include <algorithm>
 
@@ -530,7 +531,7 @@ void interpolateParametricCoordinates(
   else if (md == 2)
     interpolateParametricCoordinatesOnFace(m, g, t, a, b, p);
   else
-    printf("model entity must be an edge or a face\n");
+    lion_oprint(1,"model entity must be an edge or a face\n");
 }
 
 static void transferParametricBetween(

--- a/ma/maSnapper.cc
+++ b/ma/maSnapper.cc
@@ -12,6 +12,7 @@
 #include "maShapeHandler.h"
 #include <apfCavityOp.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <iostream>
 
 namespace ma {
@@ -337,8 +338,7 @@ bool FirstProblemPlane::find()
 
     if (ok){
       if (isInf)
-      	std::cout << "Info: Found Infinitely Many Intersection Points!" <<
-      	  std::endl;
+        lion_oprint(1, "Info: Found Infinitely Many Intersection Points!\n");
       Vector newDirection = intersect - ray.start;
       if (newDirection.getLength() < minDist) {
 	dists.push_back(newDirection.getLength());
@@ -423,8 +423,8 @@ FirstProblemPlane::intersectRayFace(const Ray& ray, const std::vector<Vector>& c
   bool res = false;
   isInf = false;
   if (coords.size() != 3){
-    std::cout << "coords.size() is " << coords.size() << std::endl;
-    std::cout << "No implementation for non-tri faces!" << std::endl;
+    lion_oprint(1,"coords.size() is %d\n", coords.size());
+    lion_oprint(1,"No implementation for non-tri faces!\n");
     res = false;
   }
 

--- a/ma/maTetrahedronize.cc
+++ b/ma/maTetrahedronize.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "maTetrahedronize.h"
 #include "maCrawler.h"
 #include "maAdapt.h"
@@ -210,12 +211,12 @@ static void overrideQuadDiagonal(Adapt* a, Entity* quad, int diagonal)
         << " has conflicting overrides on its diagonal.\n";
       ss << "a negative tet WILL get produced here.\n";
       std::string s = ss.str();
-      fprintf(stderr,"%s",s.c_str());
+      lion_eprint(1,"%s",s.c_str());
     } else {
       std::stringstream ss;
       ss << "overriding diagonal at " << apf::getLinearCentroid(mesh, quad) << '\n';
       std::string s = ss.str();
-      fprintf(stderr,"%s",s.c_str());
+      lion_eprint(1,"%s",s.c_str());
       int flag = getFlagFromDiagonal(diagonal);
       int old_flag = getFlagFromDiagonal(old_diagonal);
       clearFlag(a, quad, old_flag);
@@ -229,7 +230,7 @@ static void overrideQuadDiagonal(Adapt* a, Entity* quad, int diagonal)
     ss << "diagonal at " << apf::getLinearCentroid(mesh, quad)
        << " had a consistent override.\n";
     std::string s = ss.str();
-    fprintf(stderr,"%s",s.c_str());
+    lion_eprint(1,"%s",s.c_str());
   }
 }
 
@@ -261,7 +262,7 @@ struct UnsafePyramidOverride : public apf::CavityOp
          << " has no good rotation!\n";
       ss << "a negative tet WILL get produced here.\n";
       std::string s = ss.str();
-      fprintf(stderr,"%s",s.c_str());
+      lion_eprint(1,"%s",s.c_str());
       return SKIP;
     }
     Entity* faces[5];
@@ -320,7 +321,7 @@ struct UnsafePrismOverride : public apf::CavityOp
          << " has no good diagonals!\n";
       ss << "a negative tet WILL get produced here.\n";
       std::string s = ss.str();
-      fprintf(stderr,"%s",s.c_str());
+      lion_eprint(1,"%s",s.c_str());
       return SKIP;
     }
     Entity* faces[5];
@@ -391,7 +392,7 @@ struct UnsafePrismOverride : public apf::CavityOp
          << " has no safe acyclic diagonals\n";
       ss << "will try cyclic diagonals\n";
       std::string s = ss.str();
-      fprintf(stderr, "%s", s.c_str());
+      lion_eprint(1, "%s", s.c_str());
     }
     if (areDiagonalsAllowed(0, allowed_diagonals)) {
       enforceDiagonals(0);
@@ -407,7 +408,7 @@ struct UnsafePrismOverride : public apf::CavityOp
          << " has no safe diagonals!\n";
       ss << "A negative tet WILL get made here\n";
       std::string s = ss.str();
-      fprintf(stderr, "%s", s.c_str());
+      lion_eprint(1, "%s", s.c_str());
     }
   }
   Adapt* a;

--- a/mds/apfBox.cc
+++ b/mds/apfBox.cc
@@ -3,6 +3,7 @@
 #include "apfMDS.h"
 #include <gmi_lookup.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 namespace apf {
@@ -17,7 +18,7 @@ int& Indices::operator[](int i)
     case 0: return x;
     case 1: return y;
     case 2: return z;
-    default: printf("i must be in {0,1,2}"); abort(); return x;
+    default: lion_oprint(1,"i must be in {0,1,2}"); abort(); return x;
   }
 }
 

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -9,6 +9,7 @@
 *******************************************************************************/
 
 #include <PCU.h>
+#include <lionPrint.h>
 #include "apfMDS.h"
 #include "mds_apf.h"
 #include "apfPM.h"
@@ -442,7 +443,7 @@ class MeshMDS : public Mesh2
     void getTag(MeshEntity* e, MeshTag* t, void* data)
     {
       if (!hasTag(e,t)) {
-        fprintf(stderr, "expected tag \"%s\" on entity type %d\n",
+        lion_eprint(1, "expected tag \"%s\" on entity type %d\n",
             getTagName(t), getType(e));
         abort();
       }
@@ -576,7 +577,7 @@ class MeshMDS : public Mesh2
       mesh = mds_write_smb(mesh, fileName, 0, this);
       double t1 = PCU_Time();
       if (!PCU_Comm_Self())
-        printf("mesh %s written in %f seconds\n", fileName, t1 - t0);
+        lion_oprint(1,"mesh %s written in %f seconds\n", fileName, t1 - t0);
     }
     void destroyNative()
     {
@@ -663,9 +664,9 @@ class MeshMDS : public Mesh2
       int t = apf2mds(type);
       int dim = mds_dim[t];
       if (dim > mesh->mds.d) {
-        fprintf(stderr,"error: creating entity of dimension %d "
+        lion_eprint(1,"error: creating entity of dimension %d "
                        "in mesh of dimension %d\n", dim, mesh->mds.d);
-        fprintf(stderr,"please use apf::changeMdsDimension\n");
+        lion_eprint(1,"please use apf::changeMdsDimension\n");
         abort();
       }
       mds_set s;
@@ -786,7 +787,7 @@ Mesh2* loadMdsMesh(gmi_model* model, const char* meshfile)
   m->acceptChanges();
 
   if (!PCU_Comm_Self())
-    printf("mesh %s loaded in %f seconds\n", meshfile, PCU_Time() - t0);
+    lion_oprint(1,"mesh %s loaded in %f seconds\n", meshfile, PCU_Time() - t0);
   printStats(m);
   warnAboutEmptyParts(m);
   return m;
@@ -798,7 +799,7 @@ Mesh2* loadMdsMesh(const char* modelfile, const char* meshfile)
   static gmi_model* model;
   model = gmi_load(modelfile);
   if (!PCU_Comm_Self())
-    printf("model %s loaded in %f seconds\n", modelfile, PCU_Time() - t0);
+    lion_oprint(1,"model %s loaded in %f seconds\n", modelfile, PCU_Time() - t0);
 
   return loadMdsMesh(model, meshfile);
 }
@@ -816,7 +817,7 @@ void reorderMdsMesh(Mesh2* mesh, MeshTag* t)
   }
   m->mesh = mds_reorder(m->mesh, 0, vert_nums);
   if (!PCU_Comm_Self())
-    printf("mesh reordered in %f seconds\n", PCU_Time()-t0);
+    lion_oprint(1,"mesh reordered in %f seconds\n", PCU_Time()-t0);
 }
 
 Mesh2* expandMdsMesh(Mesh2* m, gmi_model* g, int inputPartCount)
@@ -851,7 +852,7 @@ Mesh2* expandMdsMesh(Mesh2* m, gmi_model* g, int inputPartCount)
   apf::remapPartition(m, expand);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("mesh expanded from %d to %d parts in %f seconds\n",
+    lion_oprint(1,"mesh expanded from %d to %d parts in %f seconds\n",
         inputPartCount, outputPartCount, t1 - t0);
   return m;
 }
@@ -866,7 +867,7 @@ Mesh2* repeatMdsMesh(Mesh2* m, gmi_model* g, Migration* plan,
   m->migrate(plan);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("mesh migrated from %d to %d in %f seconds\n",
+    lion_oprint(1,"mesh migrated from %d to %d in %f seconds\n",
         PCU_Comm_Peers() / factor,
         PCU_Comm_Peers(),
         t1 - t0);

--- a/mds/mds.c
+++ b/mds/mds.c
@@ -15,6 +15,7 @@
 #include <pcu_util.h>
 #include <PCU.h>
 #include <reel.h>
+#include <lionPrint.h>
 
 static void* mds_realloc(void* p, size_t n)
 {
@@ -537,10 +538,10 @@ static mds_id alloc_ent(struct mds* m, int t)
     grow(m,t);
   ++(m->n[t]);
   if ((sizeof(mds_id) < 8) && (m->n[t] == 10 * 1000 * 1000)) {
-    fprintf(stderr, "your mesh over %ld entities of type %d but sizeof(mds_id) = %zu !\n",
+    lion_eprint(1, "your mesh over %ld entities of type %d but sizeof(mds_id) = %zu !\n",
         ((long)(m->n[t])), t, sizeof(mds_id));
-    fprintf(stderr, "INTEGER OVERFLOW COULD OCCUR SOON\n");
-    fprintf(stderr, "please recompile with -DMDS_ID_TYPE=long\n");
+    lion_eprint(1, "INTEGER OVERFLOW COULD OCCUR SOON\n");
+    lion_eprint(1, "please recompile with -DMDS_ID_TYPE=long\n");
   }
   if (m->first_free[t] == MDS_NONE)
     id = ID(t,m->n[t] - 1);

--- a/mds/mdsANSYS.cc
+++ b/mds/mdsANSYS.cc
@@ -1,4 +1,5 @@
 #include "apfMDS.h"
+#include <lionPrint.h>
 #include <apfMesh2.h>
 #include <apfShape.h>
 #include <apfNumbering.h>
@@ -79,7 +80,7 @@ static void parseNodes(const char* nodefile, Nodes& nodes)
 {
   std::ifstream f(nodefile);
   if (!f.is_open()) {
-    fprintf(stderr, "couldn't open ANSYS node file \"%s\"\n", nodefile);
+    lion_eprint(1, "couldn't open ANSYS node file \"%s\"\n", nodefile);
     abort();
   }
   std::pair<int, apf::Vector3> entry;
@@ -94,7 +95,7 @@ static Mesh2* parseElems(const char* elemfile, Nodes& nodes)
   Mesh2* m = 0;
   std::ifstream f(elemfile);
   if (!f.is_open()) {
-    fprintf(stderr, "couldn't open ANSYS elem file \"%s\"\n", elemfile);
+    lion_eprint(1, "couldn't open ANSYS elem file \"%s\"\n", elemfile);
     abort();
   }
   Vertices verts;
@@ -118,7 +119,7 @@ static Mesh2* parseElems(const char* elemfile, Nodes& nodes)
     Downward ev;
     for (int i = 0; i < nen; ++i)
       if (!nodes.count(en[i])) {
-        fprintf(stderr, "node %d in file \"%s\" not found in node file\n",
+        lion_eprint(1, "node %d in file \"%s\" not found in node file\n",
             en[i], elemfile);
         abort();
       }

--- a/mds/mdsGmsh.cc
+++ b/mds/mdsGmsh.cc
@@ -3,6 +3,7 @@
 #include "apfMesh2.h"
 #include "apfShape.h"
 #include "gmi.h" /* this is for gmi_getline... */
+#include <lionPrint.h>
 
 #include <cstdio>
 #include <cstring>
@@ -61,7 +62,7 @@ void initReader(Reader* r, apf::Mesh2* m, const char* filename)
   r->mesh = m;
   r->file = fopen(filename, "r");
   if (!r->file) {
-    fprintf(stderr,"couldn't open Gmsh file \"%s\"\n",filename);
+    lion_eprint(1,"couldn't open Gmsh file \"%s\"\n",filename);
     abort();
   }
   r->line = static_cast<char*>(malloc(1));

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -7,6 +7,7 @@
 #include <cstdio>
 #include <cstring>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 /*
@@ -42,7 +43,7 @@ namespace {
   struct header {
     unsigned nvtx, ntri, nquad, ntet, npyr, nprz, nhex;
     void print() {
-      fprintf(stderr,
+      lion_eprint(1,
           "nvtx %u ntri %u nquad %u ntet %u npyr %u nprz %u nhex %u\n",
           nvtx,ntri,nquad,ntet,npyr,nprz,nhex);
     }
@@ -52,7 +53,7 @@ namespace {
     r->mesh = m;
     r->file = fopen(filename, "rb");
     if (!r->file) {
-      fprintf(stderr,"ERROR couldn't open ugrid file \"%s\"\n",filename);
+      lion_eprint(1,"ERROR couldn't open ugrid file \"%s\"\n",filename);
       abort();
     }
     unsigned endian = -1;
@@ -61,7 +62,7 @@ namespace {
     } else if ( strstr(filename, ".lb8.ugrid") ) {
       endian = PCU_LITTLE_ENDIAN;
     } else {
-      fprintf(stderr,
+      lion_eprint(1,
           "ERROR file extension of \"%s\" is not supported\n", filename);
       exit(EXIT_FAILURE);
     }
@@ -129,7 +130,7 @@ namespace {
       r->nodeMap[id] = makeVtx(r,p,0);
     }
     free(xyz);
-    fprintf(stderr, "read %d vtx\n", h->nvtx);
+    lion_eprint(1, "read %d vtx\n", h->nvtx);
   }
 
   void setNodeIds(Reader* r, header* h) {
@@ -189,7 +190,7 @@ namespace {
     }
     free(vtx);
     free(tags);
-    fprintf(stderr, "set %d %s face tags\n",
+    lion_eprint(1, "set %d %s face tags\n",
         nfaces, apf::Mesh::typeName[apfType]);
   }
 
@@ -227,7 +228,7 @@ namespace {
       PCU_ALWAYS_ASSERT(elm);
     }
     free(vtx);
-    fprintf(stderr, "read %d %s\n", nelms, apf::Mesh::typeName[apfType]);
+    lion_eprint(1, "read %d %s\n", nelms, apf::Mesh::typeName[apfType]);
   }
 
   void readElms(Reader* r, header* h) {
@@ -299,7 +300,7 @@ namespace {
         }
         numparts++; //we want count, not rank
         fclose(f);
-        fprintf(stderr, "read ptn for %d parts\n", numparts);
+        lion_eprint(1, "read ptn for %d parts\n", numparts);
       }
       ~ptnstats() {
         delete [] ptn;
@@ -358,7 +359,7 @@ namespace {
       }
     }
     free(vtx);
-    fprintf(stderr, "read %d %s\n", nelms, apf::Mesh::typeName[apfType]);
+    lion_eprint(1, "read %d %s\n", nelms, apf::Mesh::typeName[apfType]);
   }
 
   void printPtnStats(apf::Mesh2* m, const char* ufile, const char* ptnFile,
@@ -397,7 +398,7 @@ namespace {
     double imbvtx = maxvtx / avgvtx;
     double imbelm = maxelm / avgelm;
     double imbelmW = maxelmW / avgelmW;
-    fprintf(stderr, "imbvtx %.3f imbelmW %.3f imbelm %.3f "
+    lion_eprint(1, "imbvtx %.3f imbelmW %.3f imbelm %.3f "
         "avgvtx %.3f avgelmW %.3f avgelm %.3f\n",
         imbvtx, imbelmW, imbelm, avgvtx, avgelmW, avgelm);
   }
@@ -409,7 +410,7 @@ namespace apf {
     Mesh2* m = makeEmptyMdsMesh(g, 0, false);
     apf::changeMdsDimension(m, 3);
     readUgrid(m, filename);
-    fprintf(stderr,"vtx %lu edge %lu face %lu rgn %lu\n",
+    lion_eprint(1,"vtx %lu edge %lu face %lu rgn %lu\n",
         m->count(0), m->count(1), m->count(2), m->count(3));
     return m;
   }

--- a/mds/mds_smb.c
+++ b/mds/mds_smb.c
@@ -16,6 +16,7 @@
 #include <pcu_util.h>
 #include <PCU.h>
 #include <pcu_io.h>
+#include <lionPrint.h>
 #include <reel.h>
 #include <sys/types.h> /*required for mode_t for mkdir on some systems*/
 #include <sys/stat.h> /*using POSIX mkdir call for SMB "foo/" path*/
@@ -756,11 +757,11 @@ struct mds_apf* mds_write_smb(struct mds_apf* m, const char* pathname,
   char* filename;
   int zip;
   if (ignore_peers && (!is_compact(m))) {
-    if(!PCU_Comm_Self()) fprintf(stderr, "%s", reorderWarning);
+    if(!PCU_Comm_Self()) lion_eprint(1, "%s", reorderWarning);
     m = mds_reorder(m, 1, mds_number_verts_bfs(m));
   }
   if ((!ignore_peers) && PCU_Or(!is_compact(m))) {
-    if(!PCU_Comm_Self()) fprintf(stderr, "%s", reorderWarning);
+    if(!PCU_Comm_Self()) lion_eprint(1, "%s", reorderWarning);
     m = mds_reorder(m, 0, mds_number_verts_bfs(m));
   }
   filename = handle_path(pathname, 1, &zip, ignore_peers);

--- a/omega_h/apfOmega_h.cc
+++ b/omega_h/apfOmega_h.cc
@@ -9,6 +9,7 @@
 #include <apfShape.h>
 #include <PCU.h>
 #include <apf.h>
+#include <lionPrint.h>
 
 #include <Omega_h_array.hpp>
 #include <Omega_h_mesh.hpp>
@@ -125,7 +126,7 @@ static void field_to_osh(osh::Mesh* om, apf::Field* f) {
     ent_dim = dim;
   } else {
     if (!PCU_Comm_Self()) {
-      std::cout << "not copying field " << name << " to Omega_h\n";
+      lion_oprint(1,"not copying field %s to Omega_h\n",name.c_str());
     }
     return;
   }
@@ -181,7 +182,7 @@ static void field_from_osh(apf::Mesh* am, osh::Tag<osh::Real> const* tag,
   else if (ent_dim == dim) shape = apf::getIPFitShape(dim, 1);
   else {
     if (!PCU_Comm_Self()) {
-      std::cout << "not copying field " << name << " from Omega_h\n";
+      lion_oprint(1,"not copying field %s to Omega_h\n",name.c_str());
     }
     return;
   }

--- a/parma/diffMC/maximalIndependentSet/mersenne_twister.cc
+++ b/parma/diffMC/maximalIndependentSet/mersenne_twister.cc
@@ -1,6 +1,7 @@
 #include "mersenne_twister.h"
 #include "PCU.h"
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -35,7 +36,7 @@ static int mti = N + 1; /* mti == N + 1 means mt is not initialized */
 namespace {
   void fail(const char* msg) {
     if( ! PCU_Comm_Self() )
-      fprintf(stderr, "%s", msg);
+      lion_eprint(1, "%s", msg);
     exit(EXIT_FAILURE);
   }
 }

--- a/parma/diffMC/maximalIndependentSet/mis.h
+++ b/parma/diffMC/maximalIndependentSet/mis.h
@@ -17,7 +17,7 @@ for (t::iterator (i) = (w).begin(); \
      (i) != (w).end(); ++(i))
 
 #define MIS_FAIL(message)\
-{fprintf(stderr,"MIS ERROR: %s: " message "\n", __func__);\
+{lion_eprint(1,"MIS ERROR: %s: " message "\n", __func__);\
 abort();}
 #define MIS_FAIL_IF(condition,message)\
 if (condition)\

--- a/parma/diffMC/maximalIndependentSet/misLuby.cc
+++ b/parma/diffMC/maximalIndependentSet/misLuby.cc
@@ -7,6 +7,7 @@
 #include <time.h>
 #include <stdlib.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <locale>
 
 #include <map>

--- a/parma/diffMC/maximalIndependentSet/test/testMIS.cc
+++ b/parma/diffMC/maximalIndependentSet/test/testMIS.cc
@@ -399,7 +399,7 @@ int test_StarA(const int rank, const int totNumParts,
         adjPIDItr != part.adjPartIds.end();
         adjPIDItr++) {
       if (*adjPIDItr < 0 || *adjPIDItr >= totNumParts) {
-        printf("ERROR [%d] adjPartId=%d\n", rank, *adjPIDItr);
+        lion_oprint(1,"ERROR [%d] adjPartId=%d\n", rank, *adjPIDItr);
         return 1;
       }
     }
@@ -520,20 +520,20 @@ int test_4partsA(const int rank, const int totNumParts,
                          1, MPI_INT, 0, MPI_COMM_WORLD);
     int sizeIS = 0;
     if (rank == 0) {
-        printf("MIS: ");
+        lion_oprint(1,"MIS: ");
         for (int i = 0; i < totNumParts; ++i) {
             if (globalIsInMIS[i]) {
-                printf(" %d ", i);
+                lion_oprint(1," %d ", i);
                 ++sizeIS;
             }
         }
-        printf("\n");
+        lion_oprint(1,"\n");
         delete [] globalIsInMIS;
 
         if (sizeIS < totNumParts / 3) {
             return 1;
         } else {
-            printf("\n\nDEBUG |independent set| = %d\n", sizeIS);
+            lion_oprint(1,"\n\nDEBUG |independent set| = %d\n", sizeIS);
             return 0;
         }
     } else {
@@ -593,20 +593,20 @@ int test_4partsB(const int rank, const int totNumParts,
         0, MPI_COMM_WORLD);
     int sizeIS = 0;
     if (rank == 0) {
-        printf("MIS: ");
+        lion_oprint(1,"MIS: ");
         for (int i = 0; i < totNumParts; ++i) {
             if (globalIsInMIS[i]) {
-                printf(" %d ", i);
+                lion_oprint(1," %d ", i);
                 ++sizeIS;
             }
         }
-        printf("\n");
+        lion_oprint(1,"\n");
         delete [] globalIsInMIS;
 
         if (sizeIS < totNumParts / 3) {
             return 1;
         } else {
-            printf("\n\nDEBUG |independent set| = %d\n", sizeIS);
+            lion_oprint(1,"\n\nDEBUG |independent set| = %d\n", sizeIS);
             return 0;
         }
     } else {
@@ -661,20 +661,20 @@ int test_4partsC(const int rank, const int totNumParts,
         0, MPI_COMM_WORLD);
     int sizeIS = 0;
     if (rank == 0) {
-        printf("MIS: ");
+        lion_oprint(1,"MIS: ");
         for (int i = 0; i < totNumParts; ++i) {
             if (globalIsInMIS[i]) {
-                printf(" %d ", i);
+                lion_oprint(1," %d ", i);
                 ++sizeIS;
             }
         }
-        printf("\n");
+        lion_oprint(1,"\n");
         delete [] globalIsInMIS;
 
         if (sizeIS < totNumParts / 3) {
             return 1;
         } else {
-            printf("\n\nDEBUG |independent set| = %d\n", sizeIS);
+            lion_oprint(1,"\n\nDEBUG |independent set| = %d\n", sizeIS);
             return 0;
         }
     } else {
@@ -683,8 +683,8 @@ int test_4partsC(const int rank, const int totNumParts,
 }
 
 void printUsage(char* exe) {
-    fprintf(stderr, "Usage: %s -t test [-n number of parts] [-s random number seed] [-d] \n", exe);
-    fprintf(stderr, "-d enables debug mode\n"
+    lion_eprint(1, "Usage: %s -t test [-n number of parts] [-s random number seed] [-d] \n", exe);
+    lion_eprint(1, "-d enables debug mode\n"
             "-s specify an unsigned integer to seed the random number generator\n"
             "-n specify the number of parts per process, default is 1\n"
             "-r disable pre-defined random numbers for test 0, 1 and 2\n"
@@ -758,7 +758,7 @@ int main(int argc, char** argv) {
       default:
       case -1:
         if (0 == rank) {
-          printf("Test number not recognized\n");
+          lion_oprint(1,"Test number not recognized\n");
           printUsage(argv[0]);
         }
         MPI_Finalize();
@@ -786,9 +786,9 @@ int main(int argc, char** argv) {
 
     if (0 == rank) {
         if (1 == ierr) {
-            printf("failed\n");
+            lion_oprint(1,"failed\n");
         } else {
-            printf("passed.\n");
+            lion_oprint(1,"passed.\n");
         }
     }
     misFinalize();

--- a/parma/diffMC/parma_commons.cc
+++ b/parma/diffMC/parma_commons.cc
@@ -1,5 +1,6 @@
 #include "parma_commons.h"
 #include "PCU.h"
+#include <lionPrint.h>
 #include <math.h>
 #include <unistd.h>
 #include <stdio.h>
@@ -50,26 +51,25 @@ void parmaCommons::printElapsedTime(const char* fn, double elapsed) {
       status("%s elapsed time %lf seconds\n", fn, elapsed);
 }
 
-#define print(fmt) \
-  va_list ap; \
-  va_start(ap,fmt); \
-  vfprintf(stdout,fmt,ap); \
-  va_end(ap);
-
 void parmaCommons::debug(bool isActive, const char* fmt,...) {
   if(!isActive) return;
-  printf("PARMA_DEBUG ");
-  print(fmt);
+  lion_oprint(2,"PARMA_DEBUG ");
+  lion_oprint(2,fmt);
 }
 
 void parmaCommons::status(const char* fmt,...) {
-  printf("PARMA_STATUS ");
-  print(fmt);
+  lion_oprint(1, "PARMA_STATUS ");
+  va_list ap;
+  va_start(ap,fmt);
+  lion_voprint(1, fmt, ap);
+  va_end(ap);
 }
 
 void parmaCommons::error(const char* fmt,...) {
-  printf("PARMA_ERROR ");
-  print(fmt);
+  lion_oprint(1,"PARMA_ERROR ");
+  va_list ap;
+  va_start(ap,fmt);
+  lion_voprint(1, fmt, ap);
+  va_end(ap);
 }
-
 

--- a/parma/diffMC/parma_ghostMPAS.cc
+++ b/parma/diffMC/parma_ghostMPAS.cc
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include "parma.h"
 #include "parma_balancer.h"
 #include "parma_step.h"
@@ -20,7 +21,7 @@ namespace {
         sideTol = static_cast<int>(parma::avgSharedSides(s));
         delete s;
         if( !PCU_Comm_Self() && verbose )
-          fprintf(stdout, "sideTol %d\n", sideTol);
+          lion_oprint(1, "sideTol %d\n", sideTol);
       }
       bool runStep(apf::MeshTag* wtag, double tolerance) {
         parma::Sides* s = parma::makeElmBdrySides(mesh);
@@ -31,7 +32,7 @@ namespace {
         monitorUpdate(maxElmImb, iS, iA);
         monitorUpdate(avgSides, sS, sA);
         if( !PCU_Comm_Self() && verbose )
-          fprintf(stdout, "avgSides %f\n", avgSides);
+          lion_oprint(1, "avgSides %f\n", avgSides);
 
         parma::Weights* w =
           parma::makeGhostMPASWeights(mesh, wtag, s, layers, bridge);

--- a/parma/diffMC/zeroOneKnapsack.c
+++ b/parma/diffMC/zeroOneKnapsack.c
@@ -1,4 +1,5 @@
 #include "zeroOneKnapsack.h"
+#include <lionPrint.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -47,22 +48,22 @@ void destroyKnapsack(Knapsack knapsack) {
 void printTable(Knapsack knapsack) {
   size_t i, j;
   zoks k = (zoks) knapsack;
-  printf("===== Table =====\n");
-  printf("%3s | ", "");
+  lion_oprint(1,"===== Table =====\n");
+  lion_oprint(1,"%3s | ", "");
   for(j=0; j<k->numItems; j++)
-    printf("%3lu", k->weight[j]);
-  printf("\n");
-  printf("%3s  ","---");
+    lion_oprint(1,"%3lu", k->weight[j]);
+  lion_oprint(1,"\n");
+  lion_oprint(1,"%3s  ","---");
   for(j=0; j<k->numItems; j++)
-    printf("%3s","---");
-  printf("\n");
+    lion_oprint(1,"%3s","---");
+  lion_oprint(1,"\n");
   for(i=1; i<=k->maxWeight; i++){
-    printf("%3lu | ", i);
+    lion_oprint(1,"%3lu | ", i);
     for(j=0; j<k->numItems; j++)
-      printf("%3lu", k->M[j][i]);
-    printf("\n");
+      lion_oprint(1,"%3lu", k->M[j][i]);
+    lion_oprint(1,"\n");
   }
-  printf("===== Table =====\n");
+  lion_oprint(1,"===== Table =====\n");
 }
 
 size_t* getSolution(Knapsack knapsack, size_t* sz) {

--- a/parma/diffMC/zeroOneKnapsackTest.c
+++ b/parma/diffMC/zeroOneKnapsackTest.c
@@ -13,10 +13,10 @@ void test1() {
   Knapsack k = makeKnapsack(maxw, n, w, v);
   val = solve(k);
   printTable(k);
-  printf("val %lu\n", val);
+  lion_oprint(1,"val %lu\n", val);
   PCU_ALWAYS_ASSERT(val == 4);
   soln = getSolution(k, &size);
-  printf("size %lu soln[0] %lu\n", size, soln[0]);
+  lion_oprint(1,"size %lu soln[0] %lu\n", size, soln[0]);
   PCU_ALWAYS_ASSERT(size == 1);
   PCU_ALWAYS_ASSERT(soln[0] == 2);
   destroyKnapsack(k);
@@ -34,10 +34,10 @@ void test2() {
   Knapsack k = makeKnapsack(maxw, n, w, v);
   val = solve(k);
   printTable(k);
-  printf("val %lu\n", val);
+  lion_oprint(1,"val %lu\n", val);
   PCU_ALWAYS_ASSERT(val == 7);
   soln = getSolution(k, &size);
-  printf("size %lu soln[0] %lu soln[1] %lu\n", size, soln[0], soln[1]);
+  lion_oprint(1,"size %lu soln[0] %lu soln[1] %lu\n", size, soln[0], soln[1]);
   PCU_ALWAYS_ASSERT(size == 2);
   PCU_ALWAYS_ASSERT(soln[0] == 1 && soln[1] == 0);
   destroyKnapsack(k);

--- a/parma/parma.cc
+++ b/parma/parma.cc
@@ -5,6 +5,7 @@
 #include "diffMC/parma_commons.h"
 #include "diffMC/parma_convert.h"
 #include <parma_dcpart.h>
+#include <lionPrint.h>
 #include <limits>
 #include <sstream>
 #include <string>
@@ -128,7 +129,7 @@ namespace {
        << locV[0]  << ' ' <<  locV[1]  << ' ' <<  locV[2]  << ' '
        << surf/TO_DOUBLE(vol);
     std::string s = ss.str();
-    fprintf(stderr, "%s\n", s.c_str());
+    lion_eprint(1, "%s\n", s.c_str());
     PCU_Barrier();
   }
 

--- a/parma/rib/parma_mesh_rib.cc
+++ b/parma/rib/parma_mesh_rib.cc
@@ -3,6 +3,7 @@
 #include <apfPartition.h>
 #include <pcu_util.h>
 #include <apf2mth.h>
+#include <lionPrint.h>
 
 namespace parma {
 
@@ -76,7 +77,7 @@ class RibSplitter : public apf::Splitter
         }
         double t1 = PCU_Time();
         if (!PCU_Comm_Self())
-          printf("planned RIB factor %d in %f seconds\n",
+          lion_oprint(1,"planned RIB factor %d in %f seconds\n",
               multiple, t1 - t0);
       }
       return plan;

--- a/parma/rib/parma_rib.cc
+++ b/parma/rib/parma_rib.cc
@@ -4,6 +4,7 @@
 #include <mthQR.h>
 #include <mth_def.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 #include <iostream>
 #include <iomanip>
@@ -66,8 +67,6 @@ static mth::Matrix3x3<double> normalize(mth::Matrix3x3<double> const& A)
 static void getWeakestEigenvector(mth::Matrix3x3<double> const& A_in,
     mth::Vector3<double>& v)
 {
-  std::cout << std::scientific << std::setprecision(10);
-  std::cerr << std::scientific << std::setprecision(10);
   mth::Matrix3x3<double> A, l, q;
   /* this will help with general conditioning of the eigenvalue solve,
      mostly superstition at this point */

--- a/phasta/chef.cc
+++ b/phasta/chef.cc
@@ -2,6 +2,7 @@
 #include <apfMesh.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pumi_version.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -32,9 +33,10 @@ int main(int argc, char** argv)
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
   PCU_Protect();
+  lion_set_verbosity(1);
   if( !PCU_Comm_Self() ) {
-    printf("PUMI Git hash %s\n", pumi_version());
-    printf("PUMI version %s Git hash %s\n", pumi_version(), pumi_git_sha());
+    lion_oprint(1,"PUMI Git hash %s\n", pumi_version());
+    lion_oprint(1,"PUMI version %s Git hash %s\n", pumi_version(), pumi_git_sha());
   }
 #ifdef HAVE_SIMMETRIX
   MS_init();

--- a/phasta/condense.cc
+++ b/phasta/condense.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -29,12 +30,12 @@ namespace {
   void checkInputs(int argc, char** argv) {
     if ( argc != 3 ) {
       if ( !PCU_Comm_Self() )
-        printf("Usage: %s <control .inp> <reduction-factor>\n", argv[0]);
+        lion_oprint(1,"Usage: %s <control .inp> <reduction-factor>\n", argv[0]);
       MPI_Finalize();
       exit(EXIT_FAILURE);
     }
     if ( !PCU_Comm_Self() )
-      printf("Input control file %s reduction factor %s\n", argv[1], argv[2]);
+      lion_oprint(1,"Input control file %s reduction factor %s\n", argv[1], argv[2]);
   }
 }
 
@@ -42,6 +43,7 @@ int main(int argc, char** argv) {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
   PCU_Protect();
+  lion_set_verbosity(1);
   checkInputs(argc,argv);
 #ifdef HAVE_SIMMETRIX
   Sim_readLicenseFile(0);

--- a/phasta/cut_interface.cc
+++ b/phasta/cut_interface.cc
@@ -2,6 +2,7 @@
 #include "phInterfaceCutter.h"
 #include "phAttrib.h"
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <SimUtil.h>
 #include <SimModel.h>
@@ -23,11 +24,12 @@ char const* outfile;
 int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
+  lion_set_verbosity(1);
   if (argc < 4 || argc > 5) {
-    fprintf(stderr,"Usage: %s <model .x_t> <attributes .smd> <in mesh> <out mesh>\n", argv[0]);
-    fprintf(stderr,"       to take model and attributes in separate files\n");
-    fprintf(stderr,"Usage: %s <model+attributes .smd> <in mesh> <out mesh>\n", argv[0]);
-    fprintf(stderr,"       to take combined model and attributes file (by simTranslate)\n");
+    lion_eprint(1,"Usage: %s <model .x_t> <attributes .smd> <in mesh> <out mesh>\n", argv[0]);
+    lion_eprint(1,"       to take model and attributes in separate files\n");
+    lion_eprint(1,"Usage: %s <model+attributes .smd> <in mesh> <out mesh>\n", argv[0]);
+    lion_eprint(1,"       to take combined model and attributes file (by simTranslate)\n");
     return 0;
   }
   PCU_Comm_Init();

--- a/phasta/migrate_interface.cc
+++ b/phasta/migrate_interface.cc
@@ -3,6 +3,7 @@
 #include "phInterfaceCutter.h"
 #include <ph.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMesh2.h>
 #include <apfMDS.h>
@@ -34,10 +35,10 @@ void getConfig(int argc, char** argv)
 {
   if (argc < 4 || argc > 5) {
     if ( !PCU_Comm_Self() ) {
-      fprintf(stderr,"Usage: %s <model .x_t> <attributes .smd> <in mesh> <out mesh>\n", argv[0]);
-      fprintf(stderr,"       to take model and attributes in separate files\n");
-      fprintf(stderr,"Usage: %s <model+attributes .smd> <in mesh> <out mesh>\n", argv[0]);
-      fprintf(stderr,"       to take combined model and attributes file (by simTranslate)\n");}
+      lion_eprint(1,"Usage: %s <model .x_t> <attributes .smd> <in mesh> <out mesh>\n", argv[0]);
+      lion_eprint(1,"       to take model and attributes in separate files\n");
+      lion_eprint(1,"Usage: %s <model+attributes .smd> <in mesh> <out mesh>\n", argv[0]);
+      lion_eprint(1,"       to take combined model and attributes file (by simTranslate)\n");}
     MPI_Finalize();
     exit(EXIT_FAILURE);
   }
@@ -58,6 +59,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/phasta/ph.cc
+++ b/phasta/ph.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 
 #include "ph.h"
 #include <apfMDS.h>
@@ -29,9 +30,9 @@ void fail(const char* format, ...)
 {
   va_list ap;
   va_start(ap, format);
-  vfprintf(stderr, format, ap);
+  lion_veprint(1, format, ap);
   va_end(ap);
-  fprintf(stderr,"\n");
+  lion_eprint(1,"\n");
   abort();
 }
 
@@ -124,7 +125,7 @@ void setupInputSubdir(std::string& path)
     ss << path.substr(0,found) << "/" << subGroup << "/" << path.substr(found+1);
   }
 
-//  printf("Rank: %d - Path in setupInputSubdir: %s\n", self, ss.str().c_str());
+//  lion_oprint(1,"Rank: %d - Path in setupInputSubdir: %s\n", self, ss.str().c_str());
   path = ss.str();
   PCU_Barrier();
 }

--- a/phasta/phAdapt.cc
+++ b/phasta/phAdapt.cc
@@ -3,6 +3,7 @@
 #include "ph.h"
 #include <ma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <sam.h>
 #include <samSz.h>
 #include <parma.h>
@@ -32,7 +33,7 @@ void setupBalance(const char* key, std::string& method,
     zoltanRibBal = false;
   } else {
     if (!PCU_Comm_Self())
-      fprintf(stderr,
+      lion_eprint(1,
           "warning: ignoring unknown value of %s = %s\n",
           key, method.c_str());
   }
@@ -40,7 +41,7 @@ void setupBalance(const char* key, std::string& method,
 
 void setupMatching(ma::Input& in) {
   if (!PCU_Comm_Self())
-    printf("Matched mesh: disabling"
+    lion_oprint(1,"Matched mesh: disabling"
            " snapping, and shape correction,\n");
   in.shouldSnap = false;
   in.shouldFixShape = false;
@@ -114,7 +115,7 @@ static int getShrinkFactor(apf::Mesh* m, double minPartDensity) {
 static void warnAboutShrinking(int factor) {
   int nprocs = PCU_Comm_Peers() / factor;
   if (!PCU_Comm_Self()) {
-    fprintf(stderr,"sensing mesh is spread too thin: "
+    lion_eprint(1,"sensing mesh is spread too thin: "
                    "adapting with %d procs\n", nprocs);
   }
 }
@@ -123,7 +124,7 @@ void adaptShrunken(apf::Mesh2* m, double minPartDensity,
                    Parma_GroupCode& callback) {
   int factor = getShrinkFactor(m, minPartDensity);
   if (!PCU_Comm_Self())
-    fprintf(stderr,"adaptShrunken limit set to %f factor computed as %d\n", minPartDensity, factor);
+    lion_eprint(1,"adaptShrunken limit set to %f factor computed as %d\n", minPartDensity, factor);
   if (factor == 1) {
     callback.run(0);
   } else {
@@ -221,7 +222,7 @@ namespace chef {
     // assert that there is a scalar component
     int size = apf::countComponents(soln);
     PCU_ALWAYS_ASSERT(size == in.ensa_dof);
-    fprintf(stderr, "found %d components in solution field\n", size);
+    lion_eprint(1, "found %d components in solution field\n", size);
     // get the size field
     apf::Field* szFld = samSz::isoSize(m);
     apf::NewArray<double> s(in.ensa_dof);

--- a/phasta/phAttrib.cc
+++ b/phasta/phAttrib.cc
@@ -1,5 +1,6 @@
 #include "phAttrib.h"
 #include "gmi_sim.h"
+#include <lionPrint.h>
 #include <SimAttribute.h>
 #include <SimUtil.h>
 #include <cstdlib>
@@ -27,7 +28,7 @@ struct Tensor0BC : public SimBC
   Tensor0BC(pAttribute a, pGEntity ge):SimBC(ge)
   {
     if (Attribute_repType(a) != Att_tensor0) {
-      fprintf(stderr, "tensor 0 attribute does not match type\n");
+      lion_eprint(1, "tensor 0 attribute does not match type\n");
       abort();
     }
     attribute = (pAttributeTensor0)a;
@@ -45,7 +46,7 @@ struct Tensor1BC : public SimBC {
   Tensor1BC(pAttribute a, pGEntity ge):SimBC(ge)
   {
     if (Attribute_repType(a) != Att_tensor1) {
-      fprintf(stderr, "tensor 1 attribute does not match type\n");
+      lion_eprint(1, "tensor 1 attribute does not match type\n");
       abort();
     }
     attribute = (pAttributeTensor1)a;
@@ -64,7 +65,7 @@ struct CompBC : public SimBC {
   CompBC(pAttribute a, pGEntity ge):SimBC(ge)
   {
     if (Attribute_repType(a) != Att_void) {
-      fprintf(stderr, "comp1/3 attribute does not match type\n");
+      lion_eprint(1, "comp1/3 attribute does not match type\n");
       abort();
     }
     pPList children = Attribute_children(a);
@@ -77,15 +78,15 @@ struct CompBC : public SimBC {
       else if (Attribute_repType(child) == Att_tensor1)
         direction = (pAttributeTensor1) child;
       else
-        fprintf(stderr,"ignored some comp1/3 attributes...\n");
+        lion_eprint(1,"ignored some comp1/3 attributes...\n");
     }
     PList_delete(children);
     if (!magnitude) {
-      fprintf(stderr, "comp1/3 attribute does not have magnitude\n");
+      lion_eprint(1, "comp1/3 attribute does not have magnitude\n");
       abort();
     }
     if (!direction) {
-      fprintf(stderr, "comp1/3 attribute does not have direction\n");
+      lion_eprint(1, "comp1/3 attribute does not have direction\n");
       abort();
     }
   }
@@ -106,7 +107,7 @@ struct IntBC : public SimBC
   IntBC(pAttribute a, pGEntity ge):SimBC(ge)
   {
     if (Attribute_repType(a) != Att_int) {
-      fprintf(stderr, "int attribute does not match type\n");
+      lion_eprint(1, "int attribute does not match type\n");
       abort();
     }
     attribute = (pAttributeInt)a;
@@ -199,8 +200,8 @@ static void addAttribute(BCFactories& fs, pAttribute a, pGEntity ge,
 {
   std::string type = getType(a);
   if (!fs.count(type)) {
-    fprintf(stderr,"unknown attribute type \"%s\", ignoring !\n", type.c_str());
-    fprintf(stderr,"it had repType %d\n",
+    lion_eprint(1,"unknown attribute type \"%s\", ignoring !\n", type.c_str());
+    lion_eprint(1,"it had repType %d\n",
         Attribute_repType(a));
     return;
   }
@@ -225,12 +226,12 @@ namespace {
     smdl = gmi_export_sim(m);
     pAManager mngr = SModel_attManager(smdl);
     if (!mngr) {
-      fprintf(stderr,"Simmetrix model did not come with an Attribute Manager\n");
+      lion_eprint(1,"Simmetrix model did not come with an Attribute Manager\n");
       abort();
     }
     pd = AMAN_findCaseByType(mngr, "problem definition");
     if (!pd) {
-      fprintf(stderr,"no Attribute Case \"problem definition\"\n");
+      lion_eprint(1,"no Attribute Case \"problem definition\"\n");
       abort();
     }
   }

--- a/phasta/phBC.cc
+++ b/phasta/phBC.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "phBC.h"
 #ifdef HAVE_SIMMETRIX
 #include "phAttrib.h"
@@ -149,7 +150,7 @@ void loadModelAndBCs(ph::Input& in, gmi_model*& m, BCs& bcs)
   readBCs(m, attribfile, in.axisymmetry, bcs);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("\"%s\" and \"%s\" loaded in %f seconds\n", modelfile, attribfile, t1 - t0);
+    lion_oprint(1,"\"%s\" and \"%s\" loaded in %f seconds\n", modelfile, attribfile, t1 - t0);
 }
 
 struct KnownBC

--- a/phasta/phBubble.cc
+++ b/phasta/phBubble.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "phBubble.h"
 #include "phInput.h"
 #include <apfMesh.h>
@@ -24,7 +25,7 @@ void readBubbles(Bubbles& bubbles, std::string bubbleFileName)
 
   sprintf(bubblefname, "%s", bubbleFileName.c_str());
   if (!PCU_Comm_Self())
-    printf("reading bubbles info from %s\n",bubblefname);
+    lion_oprint(1,"reading bubbles info from %s\n",bubblefname);
 
   filebubble = fopen(bubblefname, "r");
   PCU_ALWAYS_ASSERT(filebubble != NULL); 
@@ -38,11 +39,11 @@ void readBubbles(Bubbles& bubbles, std::string bubbleFileName)
     bubbles.push_back(readbubble);
   }
   if(!feof(filebubble) && !PCU_Comm_Self()) // If while loop was exited for another reason then eof
-    printf("WARNING: data in %s does not match expected format\n",bubblefname);
+    lion_oprint(1,"WARNING: data in %s does not match expected format\n",bubblefname);
   fclose(filebubble);
 
   if (!PCU_Comm_Self())
-    printf("%lu bubbles found in %s\n", bubbles.size(), bubblefname);
+    lion_oprint(1,"%lu bubbles found in %s\n", bubbles.size(), bubblefname);
 
 }
 

--- a/phasta/phConstraint.cc
+++ b/phasta/phConstraint.cc
@@ -2,7 +2,9 @@
 #include <apfGeometry.h>
 #include <cstdlib>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <iostream>
+#include <sstream>
 
 namespace ph {
 
@@ -286,8 +288,11 @@ static Constraint* combinePoints(Constraint* a, Constraint* b,
   if (mb == 0)
     return takeFirst(b, a);
   /* multiple non-zero point constraints ? we got a problem. */
-  std::cerr << "ph error: point overconstraint (velocity): ";
-  std::cerr << pa->point << " and " << pb->point << dbg;
+  std::stringstream ss;
+  ss << "ph error: point overconstraint (velocity): ";
+  ss << pa->point << " and " << pb->point << dbg;
+  std::string s = ss.str();
+  lion_eprint(1,"%s",s.c_str());
   abort();
   return 0;
 }
@@ -308,8 +313,11 @@ static Constraint* combinePointsElas(Constraint* a, Constraint* b,
   if (mb == 0)
     return takeFirst(b, a);
   /* multiple non-zero point constraints ? we got a problem. */
-  std::cerr << "ph error: point overconstraint (mesh-elas): ";
-  std::cerr << pa->point << " and " << pb->point << dbg;
+  std::stringstream ss;
+  ss << "ph error: point overconstraint (mesh-elas): ";
+  ss << pa->point << " and " << pb->point << dbg;
+  std::string s = ss.str();
+  lion_eprint(1,"%s",s.c_str());
   abort();
   return 0;
 }
@@ -324,7 +332,10 @@ static Constraint* combinePlanes(Constraint* a, Constraint* b,
     return takeFirst(a, b);
   /* the planes are different, so make sure they're not parallel */
   if (apf::areParallel(pa->plane, pb->plane, 0.0)) {
-    std::cerr << "ph error: different parallel planes (velocity)" << dbg;
+    std::stringstream ss;
+    ss << "ph error: different parallel planes (velocity)" << dbg;
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
     abort();
   }
   /* different intersecting planes, combine into a line constraint */
@@ -344,7 +355,10 @@ static Constraint* combinePlanesElas(Constraint* a, Constraint* b,
     return takeFirst(a, b);
   /* the planes are different, so make sure they're not parallel */
   if (apf::areParallel(pa->plane, pb->plane, 0.0)) {
-    std::cerr << "ph error: different parallel planes (mesh-elas)" << dbg;
+    std::stringstream ss;
+    ss << "ph error: different parallel planes (mesh-elas)" << dbg;
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
     abort();
   }
   /* different intersecting planes, combine into a line constraint */
@@ -373,7 +387,10 @@ static Constraint* combineLinePlane(Constraint* a, Constraint* b,
     return takeFirst(a, b); /* keep the line */
   /* it may never intersect */
   if (apf::areParallel(line, pb->plane, 0.0)) {
-    std::cerr << "line doesn't intersect plane (velocity)" << dbg;
+    std::stringstream ss;
+    ss << "line doesn't intersect plane (velocity)" << dbg;
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
     abort();
   }
   /* okay, there is a legit intersection point. find it. */
@@ -405,7 +422,10 @@ static Constraint* combineLinePlaneElas(Constraint* a, Constraint* b,
     return takeFirst(a, b); /* keep the line */
   /* it may never intersect */
   if (apf::areParallel(line, pb->plane, 0.0)) {
-    std::cerr << "line doesn't intersect plane (mesh-elas)" << dbg;
+    std::stringstream ss;
+    ss << "line doesn't intersect plane (mesh-elas)" << dbg;
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
     abort();
   }
   /* okay, there is a legit intersection point. find it. */

--- a/phasta/phCook.cc
+++ b/phasta/phCook.cc
@@ -25,6 +25,7 @@
 #include <PCU.h>
 #include <pcu_io.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <string>
 #include <stdlib.h>
 #include <cstring>
@@ -62,7 +63,7 @@ static apf::Mesh2* loadMesh(gmi_model*& g, ph::Input& in) {
   if (ph::mesh_has_ext(meshfile, "sms")) {
     if (in.simmetrixMesh == 0) {
       if (PCU_Comm_Self()==0)
-        fprintf(stderr, "oops, turn on flag: simmetrixMesh\n");
+        lion_eprint(1, "oops, turn on flag: simmetrixMesh\n");
       in.simmetrixMesh = 1;
       in.filterMatches = 0; //not support
     }
@@ -121,7 +122,7 @@ namespace chef {
     if( fname.find(restartStr) != std::string::npos )
       PHASTAIO_OPENTIME(f = openRStreamRead(in.rs);)
     else {
-      fprintf(stderr,
+      lion_eprint(1,
         "ERROR %s type of stream %s is unknown... exiting\n",
         __func__, fname.c_str());
       exit(1);
@@ -173,7 +174,7 @@ namespace ph {
     ph::exitFilteredMatching(m);
     // a path is not needed for inmem
     if ( in.writeRestartFiles ) {
-      if(!PCU_Comm_Self()) printf("write file-based restart file\n");
+      if(!PCU_Comm_Self()) lion_oprint(1,"write file-based restart file\n");
       // store the value of the function pointer
       FILE* (*fn)(Output& out, const char* path) = out.openfile_write;
       // set function pointer for file writing
@@ -188,7 +189,7 @@ namespace ph {
     if ( ! in.outMeshFileName.empty() )
       m->writeNative(in.outMeshFileName.c_str());
     if ( in.writeGeomBCFiles ) {
-      if(!PCU_Comm_Self()) printf("write additional geomBC file for visualization\n");
+      if(!PCU_Comm_Self()) lion_oprint(1,"write additional geomBC file for visualization\n");
       // store the value of the function pointer
       FILE* (*fn)(Output& out, const char* path) = out.openfile_write;
       // set function pointer for file writing
@@ -213,7 +214,7 @@ namespace ph {
     gmi_model* g = m->getModel();
     PCU_ALWAYS_ASSERT(g);
     BCs bcs;
-    fprintf(stderr, "reading %s\n", in.attributeFileName.c_str());
+    lion_eprint(1, "reading %s\n", in.attributeFileName.c_str());
     ph::readBCs(g, in.attributeFileName.c_str(), in.axisymmetry, bcs);
     if (!in.solutionMigration)
       ph::attachZeroSolution(in, m);

--- a/phasta/phFilterMatching.cc
+++ b/phasta/phFilterMatching.cc
@@ -7,6 +7,7 @@
 #include <apf.h>
 #include <PCU.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <iostream>
 
@@ -97,7 +98,7 @@ static void getAttributeMatching(gmi_model* gm, BCs& bcs, ModelMatching& mm)
     int otherTag = *val;
     gmi_ent* oe = gmi_find(gm, bc->dim, otherTag);
     if (!oe)
-      fprintf(stderr, "model %s %d has %s %s %d,\n"
+      lion_eprint(1, "model %s %d has %s %s %d,\n"
                       "but %s %d doesn not exist in the model\n",
           apf::dimName[bc->dim], bc->tag, name.c_str(),
           apf::dimName[bc->dim], otherTag,
@@ -211,9 +212,9 @@ static void checkFilteredMatching(apf::Mesh* m, ModelMatching& mm, int dim)
       continue;
     }
     if (matches.getSize() < mm[ge].size()) {
-      std::cerr << "solution periodicity requested "
-                << "where mesh periodicity does not exist.\n"
-                << "rebuild mesh to match solution request\n";
+      lion_eprint(1,"solution periodicity requested "
+                    "where mesh periodicity does not exist.\n"
+                    "rebuild mesh to match solution request\n");
       abort();
     }
   }

--- a/phasta/phGeomBC.cc
+++ b/phasta/phGeomBC.cc
@@ -4,6 +4,7 @@
 #include "phiotimer.h"
 #include <sstream>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 namespace ph {
@@ -298,7 +299,7 @@ void writeGeomBC(Output& o, std::string path, int timestep)
   phastaio_setfile(GEOMBC_WRITE);
   FILE* f = o.openfile_write(o, path.c_str());
   if (!f) {
-    fprintf(stderr,"failed to open \"%s\"!\n", path.c_str());
+    lion_eprint(1,"failed to open \"%s\"!\n", path.c_str());
     abort();
   }
   ph_write_preamble(f);
@@ -365,7 +366,7 @@ void writeGeomBC(Output& o, std::string path, int timestep)
   PHASTAIO_CLOSETIME(fclose(f);)
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("geombc file written in %f seconds\n", t1 - t0);
+    lion_oprint(1,"geombc file written in %f seconds\n", t1 - t0);
 }
 
 }

--- a/phasta/phGrowthCurves.cc
+++ b/phasta/phGrowthCurves.cc
@@ -1,5 +1,6 @@
 #include <PCU.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include "phOutput.h"
 #include "phGrowthCurves.h"
 #include "phLinks.h"
@@ -159,7 +160,7 @@ void getGrowthCurves(Output& o)
                 //this is a blend, there will be multiple seeds
                 PList_clear(blendSeeds);
                 if(!(BL_blendSeedEdges(vertex, gFace, faceSide, gRegion, blendSeeds) == 1)){
-                  printf("%s: unexpected BL_blendSeedEdges return value\n",__func__);
+                  lion_oprint(1,"%s: unexpected BL_blendSeedEdges return value\n",__func__);
                   exit(EXIT_FAILURE);
                 }
                 PList_appPListUnique(seeds, blendSeeds);
@@ -168,7 +169,7 @@ void getGrowthCurves(Output& o)
                 //there is no seed edge
                 break;
               default:
-                printf("%s: unexpected BL_stackSeedEntity return value\n",__func__);
+                lion_oprint(1,"%s: unexpected BL_stackSeedEntity return value\n",__func__);
                 exit(EXIT_FAILURE);
     	  		}
     	  	}
@@ -203,7 +204,7 @@ void getGrowthCurves(Output& o)
 
 //    get growth vertices (growthVertices) and edges for seed
       if(!(BL_growthVerticesAndEdges((pEdge)seed, growthVertices, growthEdges) == 1)){
-        printf("%s: unexpected BL_growthVerticesAndEdges return value\n",__func__);
+        lion_oprint(1,"%s: unexpected BL_growthVerticesAndEdges return value\n",__func__);
         exit(EXIT_FAILURE);
       }
 
@@ -234,13 +235,13 @@ void getGrowthCurves(Output& o)
       o.arrays.igclv[i] = me;
     }
 
-    printf("%s: rank %d, ngc, nv: %d, %d\n", __func__, PCU_Comm_Self(), ngc, nv);
+    lion_oprint(1,"%s: rank %d, ngc, nv: %d, %d\n", __func__, PCU_Comm_Self(), ngc, nv);
 
     PCU_Add_Ints(&ngc,sizeof(ngc));
     PCU_Add_Ints(&nv,sizeof(nv));
 
     if(PCU_Comm_Self() == 0)
-      printf("%s: total ngc, nv: %d, %d\n", __func__, ngc, nv);
+      lion_oprint(1,"%s: total ngc, nv: %d, %d\n", __func__, ngc, nv);
 
     PList_delete(gEdges);
     PList_delete(gVertices);
@@ -259,7 +260,7 @@ void getGrowthCurves(Output& o)
   }
   else {
     if(PCU_Comm_Self() == 0)
-      printf("%s: warning! not implemented for MDS mesh\n",__func__);
+      lion_oprint(1,"%s: warning! not implemented for MDS mesh\n",__func__);
   }
   return;
 }

--- a/phasta/phGrowthCurves_empty.cc
+++ b/phasta/phGrowthCurves_empty.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "phGrowthCurves.h"
 #include "phOutput.h"
 namespace ph {
@@ -6,7 +7,7 @@ namespace ph {
     o.nGrowthCurves = 0;
     o.nLayeredMeshVertices = 0;
     if(PCU_Comm_Self() == 0)
-      printf("warning! \'%s\' requires the Simmetrix SimAdvMeshing library\n",__func__);
+      lion_oprint(1,"warning! \'%s\' requires the Simmetrix SimAdvMeshing library\n",__func__);
     return;
   }
 }

--- a/phasta/phIO.c
+++ b/phasta/phIO.c
@@ -5,6 +5,7 @@
 #include <pcu_io.h>
 #include <phIO.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <phiotimer.h>
 
 #define PH_LINE 1024
@@ -87,7 +88,7 @@ static int find_header(FILE* f, const char* name, char* found, char header[PH_LI
     fseek(f, bytes, SEEK_CUR);
   }
   if (!PCU_Comm_Self() && strlen(name) > 0)
-    fprintf(stderr,"warning: phIO could not find \"%s\"\n",name);
+    lion_eprint(1,"warning: phIO could not find \"%s\"\n",name);
   return 0;
 }
 
@@ -118,7 +119,7 @@ static int read_magic_number(FILE* f)
   int magic;
   if (!seek_after_header(f, magic_name)) {
     if (!PCU_Comm_Self())
-      fprintf(stderr,"warning: not swapping bytes\n");
+      lion_eprint(1,"warning: not swapping bytes\n");
     rewind(f);
     return 0;
   }

--- a/phasta/phInput.cc
+++ b/phasta/phInput.cc
@@ -5,6 +5,7 @@
 #include <set>
 #include "ph.h"
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 /** \file phInput.cc
     \brief The implementation of Chef's interface for execution control */
@@ -193,7 +194,7 @@ static bool deprecated(stringset& old, std::string const& name)
 {
   if( old.count(name) ) {
     if( !PCU_Comm_Self() )
-      fprintf(stderr, "WARNING deprecated input \"%s\" ... "
+      lion_eprint(1, "WARNING deprecated input \"%s\" ... "
           "carefully check stderr and stdout for unexpected behavior\n",
           name.c_str());
     return true;

--- a/phasta/phInterfaceCutter.cc
+++ b/phasta/phInterfaceCutter.cc
@@ -4,6 +4,7 @@
 #include <apf.h>
 #include <ph.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <iostream>
 #include <stdio.h>
 
@@ -162,13 +163,13 @@ static void cutEntities(apf::Mesh2* m, FieldBCs& fbcs, MaterialMap& mm)
     m->end(it);
     for (size_t i = 0; i < toCut.size(); ++i)
       cutEntity(m, mm, toCut[i]);
-    printf("cut %zd entities in dimension %d\n",toCut.size(),d);
+    lion_oprint(1,"cut %zd entities in dimension %d\n",toCut.size(),d);
   }
 }
 
 void cutInterface(apf::Mesh2* m, BCs& bcs)
 {
-  printf("execute PUMI cut interface\n");
+  lion_oprint(1,"execute PUMI cut interface\n");
   std::string name("DG interface");
   if (!haveBC(bcs, name))
     ph::fail("no DG interface attributes!");
@@ -193,7 +194,7 @@ int M_numVerticesInClosure(pMesh mesh, pGEntity model){
 
 void cutInterfaceSIM(apf::Mesh2* m, BCs& bcs)
 {
-  printf("execute simmetrix cut interface\n");
+  lion_oprint(1,"execute simmetrix cut interface\n");
   std::string name("DG interface");
   if (!haveBC(bcs, name))
     ph::fail("no DG interface attributes!");
@@ -215,12 +216,12 @@ void cutInterfaceSIM(apf::Mesh2* m, BCs& bcs)
   while ((ge = gmi_next(gm, git))) {
     if (ph::isInterface(gm, ge, fbcs)) {
       modelFace = (pGFace) ge;
-      printf("cutting face %d:\n",GEN_tag(modelFace));
+      lion_oprint(1,"cutting face %d:\n",GEN_tag(modelFace));
       counter = M_numVerticesInClosure(mesh, modelFace);
-      printf("  num. of mesh vertices on interface before cut: %d\n",counter);
+      lion_oprint(1,"  num. of mesh vertices on interface before cut: %d\n",counter);
       splitMeshOnGFace(pmesh, modelFace);
       counter = M_numVerticesInClosure(mesh, modelFace);
-      printf("  num. of mesh vertices on interface after cut: %d\n",counter);
+      lion_oprint(1,"  num. of mesh vertices on interface after cut: %d\n",counter);
     }
   }
   gmi_end(gm, git);
@@ -271,7 +272,7 @@ int migrateInterface(apf::Mesh2*& m, ph::BCs& bcs) {
       plan->send(e,remoteResidence);
   }
   m->end(it);
-  printf("proc-%d: number of migrating elements: %d\n",PCU_Comm_Self(),plan->count());
+  lion_oprint(1,"proc-%d: number of migrating elements: %d\n",PCU_Comm_Self(),plan->count());
 
   int totalPlan = plan->count();
   totalPlan = PCU_Add_Int(totalPlan);
@@ -288,7 +289,7 @@ bool migrateInterfaceItr(apf::Mesh2*& m, ph::BCs& bcs) {
     result = migrateInterface(m, bcs);
     itr++;
     if(itr >= maxItr) {
-      printf("migrate interface iteration more than maxItr");
+      lion_oprint(1,"migrate interface iteration more than maxItr");
       break;
     }
     if(result == -1)

--- a/phasta/phMeshQuality.cc
+++ b/phasta/phMeshQuality.cc
@@ -22,6 +22,7 @@
 
 #include <PCU.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdio>
 
 namespace ph {
@@ -205,7 +206,7 @@ void core_measure_mesh (double x1[], double x2[], double x3[], int numnp,
   else
 #endif
   {
-    printf("PUMI-based mesh doesn't have BL info. minfq is set to be 1.0\n");
+    lion_oprint(1,"PUMI-based mesh doesn't have BL info. minfq is set to be 1.0\n");
   }
 
 // restore mesh

--- a/phasta/phOutput.cc
+++ b/phasta/phOutput.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "phOutput.h"
 #include "phGrowthCurves.h"
 #include "phLinks.h"
@@ -35,11 +36,11 @@ static void checkLoadBalance(Output& o)
   double vlbratio = o.nOverlapNodes * PCU_Comm_Peers() / (double) sumOwnedNodes;
   double vlbratio_max = PCU_Max_Double(vlbratio);
   if (!PCU_Comm_Self())
-    printf("max vertex load imbalance of partitioned mesh = %f\n", vlbratio_max);
+    lion_oprint(1,"max vertex load imbalance of partitioned mesh = %f\n", vlbratio_max);
 
   int sumAllNodes = PCU_Add_Int(o.nOverlapNodes);
   if (!PCU_Comm_Self())
-    printf("ratio of sum of all vertices to sum of owned vertices = %f\n", sumAllNodes / (double) sumOwnedNodes);
+    lion_oprint(1,"ratio of sum of all vertices to sum of owned vertices = %f\n", sumAllNodes / (double) sumOwnedNodes);
 
   int dim = o.mesh->getDimension();
   int numElms = o.mesh->count(dim);
@@ -47,7 +48,7 @@ static void checkLoadBalance(Output& o)
   double elbratio = numElms * PCU_Comm_Peers() / (double) sumElms;
   double elbratio_max = PCU_Max_Double(elbratio);
   if (!PCU_Comm_Self())
-    printf("max region (3D) or face (2D) load imbalance of partitioned mesh = %f\n", elbratio_max);
+    lion_oprint(1,"max region (3D) or face (2D) load imbalance of partitioned mesh = %f\n", elbratio_max);
 }
 
 static void getCoordinates(Output& o)
@@ -346,7 +347,7 @@ static void getRigidBody(Output& o, BCs& bcs, apf::Numbering* n) {
         }
         int vID = apf::getNumber(n, e, 0, 0);
         if(f[vID] > -1 && f[vID] != rbID) {
-          fprintf(stderr,"not support multiple rigid bodies on one mesh vertex\n");
+          lion_eprint(1,"not support multiple rigid bodies on one mesh vertex\n");
         }
         else if (f[vID] == -1) {
           f[vID] = rbID;
@@ -433,7 +434,7 @@ bool checkInterface(Output& o, BCs& bcs) {
   PCU_ALWAYS_ASSERT(aID!=bID); //assert different material ID on two sides
   PCU_ALWAYS_ASSERT(a==b); //assert same number of faces on each side
   if (PCU_Comm_Self() == 0)
-    printf("Checked! Same number of faces on each side of interface.\n");
+    lion_oprint(1,"Checked! Same number of faces on each side of interface.\n");
   return true;
 }
 
@@ -840,7 +841,7 @@ static void getInitialConditions(BCs& bcs, Output& o)
   Input& in = *o.in;
   if (in.solutionMigration) {
     if (!PCU_Comm_Self())
-      printf("All attribute-based initial conditions, "
+      lion_oprint(1,"All attribute-based initial conditions, "
              "if any, "
              "are ignored due to request for SolutionMigration\n");
     return;
@@ -1052,7 +1053,7 @@ void generateOutput(Input& in, BCs& bcs, apf::Mesh* mesh, Output& o)
     initBubbles(o.mesh, in);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("generated output structs in %f seconds\n",t1 - t0);
+    lion_oprint(1,"generated output structs in %f seconds\n",t1 - t0);
 }
 
 }

--- a/phasta/phPartition.cc
+++ b/phasta/phPartition.cc
@@ -7,6 +7,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 
 #ifdef HAVE_SIMMETRIX
 #include <apfSIM.h>
@@ -128,7 +129,7 @@ void parmaTet(Input& in, apf::Mesh2* m, bool runGap) {
     double vtxImb = Parma_GetWeightedEntImbalance(m, weights, 0);
     if( vtxImb <= in.vertexImbalance ) {
       if( !PCU_Comm_Self() )
-        fprintf(stdout, "STATUS vtx imbalance target %.3f reached\n",
+        lion_oprint(1, "STATUS vtx imbalance target %.3f reached\n",
             in.vertexImbalance);
       break;
     }
@@ -190,7 +191,7 @@ void simmetrixBalance(apf::Mesh2* m)
   int currentTotalNumParts = PM_totalNumParts(pmesh);
   if (currentTotalNumParts > totalNumParts) {
     if( !PCU_Comm_Self() )
-      fprintf(stderr, "Error: cannot reduce number of partitions %d->%d\n",
+      lion_eprint(1, "Error: cannot reduce number of partitions %d->%d\n",
               currentTotalNumParts, totalNumParts);
     totalNumParts = currentTotalNumParts;
   }

--- a/phasta/phRestart.cc
+++ b/phasta/phRestart.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include "phRestart.h"
 #include <apf.h>
 #include <apfField.h>
@@ -29,7 +30,7 @@ apf::Field* extractField(apf::Mesh* m,
 {
   apf::Field* f = m->findField(packedFieldname);
   if(!f && PCU_Comm_Self() == 0)
-    fprintf(stderr, "No packed field \"%s\"", packedFieldname);
+    lion_eprint(1, "No packed field \"%s\"", packedFieldname);
   PCU_ALWAYS_ASSERT(f);
   apf::Field* rf = m->findField(requestFieldname);
   if (rf)
@@ -148,7 +149,7 @@ void attachField(
     int out_size)
 {
   if (!(in_size <= out_size))
-    fprintf(stderr, "field \"%s\" in_size %d out_size %d\n", fieldname, in_size, out_size);
+    lion_eprint(1, "field \"%s\" in_size %d out_size %d\n", fieldname, in_size, out_size);
   PCU_ALWAYS_ASSERT(in_size <= out_size);
   apf::Field* f = m->findField(fieldname);
   if( f )
@@ -199,7 +200,7 @@ void attachCellField(
     int out_size)
 {
   if (!(in_size <= out_size))
-    fprintf(stderr, "field \"%s\" in_size %d out_size %d\n", fieldname, in_size, out_size);
+    lion_eprint(1, "field \"%s\" in_size %d out_size %d\n", fieldname, in_size, out_size);
   PCU_ALWAYS_ASSERT(in_size <= out_size);
   apf::Field* f = m->findField(fieldname);
   if( f )
@@ -311,12 +312,12 @@ static bool isNodalField(const char* fieldname, int nnodes, apf::Mesh* m)
     if (!strcmp(fieldname, known_rand_fields[i]))
       return false;
   if( !PCU_Comm_Self() ) {
-    fprintf(stderr, "unknown restart field name \"%s\"\n", fieldname);
-    fprintf(stderr, "please add \"%s\" to isNodalField above line %d of %s\n",
+    lion_eprint(1, "unknown restart field name \"%s\"\n", fieldname);
+    lion_eprint(1, "please add \"%s\" to isNodalField above line %d of %s\n",
         fieldname, __LINE__, __FILE__);
   }
   if (static_cast<size_t>(nnodes) == m->count(0)) {
-    fprintf(stderr, "assuming \"%s\" is a nodal field,\n"
+    lion_eprint(1, "assuming \"%s\" is a nodal field,\n"
                     "it is the right size...\n", fieldname);
     return true;
   }
@@ -353,7 +354,7 @@ int readAndAttachField(
     out_size = in.ensa_dof;
   if (m->findField(hname)) {
     if (!PCU_Comm_Self())
-      fprintf(stderr, "field \"%s\" already attached to the mesh, "
+      lion_eprint(1, "field \"%s\" already attached to the mesh, "
                       "ignoring request to re-attach...\n", hname);
   } else {
     attachField(m, hname, data, vars, out_size);
@@ -434,7 +435,7 @@ void readAndAttachFields(Input& in, apf::Mesh* m) {
   phastaio_setfile(RESTART_READ);
   FILE* f = in.openfile_read(in, filename.c_str());
   if (!f) {
-    fprintf(stderr,"failed to open \"%s\"!\n", filename.c_str());
+    lion_eprint(1,"failed to open \"%s\"!\n", filename.c_str());
     abort();
   }
   int swap = ph_should_swap(f);
@@ -443,7 +444,7 @@ void readAndAttachFields(Input& in, apf::Mesh* m) {
   PHASTAIO_CLOSETIME(fclose(f);)
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("fields read and attached in %f seconds\n", t1 - t0);
+    lion_oprint(1,"fields read and attached in %f seconds\n", t1 - t0);
   if(in.printIOtime) phastaio_printStats();
 }
 
@@ -482,7 +483,7 @@ void detachAndWriteSolution(Input& in, Output& out, apf::Mesh* m, std::string pa
   phastaio_setfile(RESTART_WRITE);
   FILE* f = out.openfile_write(out, path.c_str());
   if (!f) {
-    fprintf(stderr,"failed to open \"%s\"!\n", path.c_str());
+    lion_eprint(1,"failed to open \"%s\"!\n", path.c_str());
     abort();
   }
   ph_write_preamble(f);
@@ -516,7 +517,7 @@ void detachAndWriteSolution(Input& in, Output& out, apf::Mesh* m, std::string pa
   PHASTAIO_CLOSETIME(fclose(f);)
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    printf("solution written in %f seconds\n", t1 - t0);
+    lion_oprint(1,"solution written in %f seconds\n", t1 - t0);
 }
 
 } //end namespace ph

--- a/phasta/ph_convert.cc
+++ b/phasta/ph_convert.cc
@@ -16,6 +16,7 @@
 #include <phInput.h>
 #include <apfGeometry.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -41,9 +42,9 @@ static void fixMatches(apf::Mesh2* m)
 {
   if (m->hasMatching()) {
     if (apf::alignMdsMatches(m))
-      printf("fixed misaligned matches\n");
+      lion_oprint(1,"fixed misaligned matches\n");
     else
-      printf("matches were aligned\n");
+      lion_oprint(1,"matches were aligned\n");
     PCU_ALWAYS_ASSERT( ! apf::alignMdsMatches(m));
   }
 }
@@ -105,18 +106,18 @@ void getConfig(int argc, char** argv) {
         break;
       case '?':
         if (!PCU_Comm_Self())
-          printf ("warning: skipping unrecognized option\n");
+          lion_oprint(1,"warning: skipping unrecognized option\n");
         break;
       default:
         if (!PCU_Comm_Self())
-          printf("Usage %s %s", argv[0], usage);
+          lion_oprint(1,"Usage %s %s", argv[0], usage);
         exit(EXIT_FAILURE);
     }
   }
 
   if(argc-optind != 3) {
     if (!PCU_Comm_Self())
-      printf("Usage %s %s", argv[0], usage);
+      lion_oprint(1,"Usage %s %s", argv[0], usage);
     exit(EXIT_FAILURE);
   }
   int i=optind;
@@ -125,9 +126,9 @@ void getConfig(int argc, char** argv) {
   smb_path = argv[i++];
 
   if (!PCU_Comm_Self()) {
-    printf ("fix_pyramids %d attach_order %d enable_log %d\n",
+    lion_oprint(1,"fix_pyramids %d attach_order %d enable_log %d\n",
             should_fix_pyramids, should_attach_order, should_log);
-    printf ("native-model \'%s\' model \'%s\' simmetrix mesh \'%s\' output mesh \'%s\'\n",
+    lion_oprint(1,"native-model \'%s\' model \'%s\' simmetrix mesh \'%s\' output mesh \'%s\'\n",
       gmi_native_path, gmi_path, sms_path, smb_path);
   }
 }
@@ -197,10 +198,10 @@ static void fixCoords(apf::Mesh2* m)
   /* admittedly not the best way of checking
      which processor had the max */
   if (global_diffs[0] && (global_max[0] == max_x_diff))
-    fprintf(stderr, "%ld spatial mismatches corrected, max distance %e\n",
+    lion_eprint(1, "%ld spatial mismatches corrected, max distance %e\n",
         global_diffs[0], global_max[0]);
   if (global_diffs[1] && (global_max[1] == max_p_diff))
-    fprintf(stderr, "%ld parametric mismatches corrected, max distance %e\n",
+    lion_eprint(1, "%ld parametric mismatches corrected, max distance %e\n",
         global_diffs[1], global_max[1]);
 }
 
@@ -246,18 +247,18 @@ int main(int argc, char** argv)
   pParMesh sim_mesh = PM_load(sms_path, simModel, progress);
   double t1 = PCU_Time();
   if(!PCU_Comm_Self())
-    fprintf(stderr, "read and created the simmetrix mesh in %f seconds\n", t1-t0);
+    lion_eprint(1, "read and created the simmetrix mesh in %f seconds\n", t1-t0);
   apf::Mesh* simApfMesh = apf::createMesh(sim_mesh);
   double t2 = PCU_Time();
   if(!PCU_Comm_Self())
-    fprintf(stderr, "created the apf_sim mesh in %f seconds\n", t2-t1);
+    lion_eprint(1, "created the apf_sim mesh in %f seconds\n", t2-t1);
   if (should_attach_order) attachOrder(simApfMesh);
   ph::buildMapping(simApfMesh);
 
   apf::Mesh2* mesh = apf::createMdsMesh(mdl, simApfMesh);
   double t3 = PCU_Time();
   if(!PCU_Comm_Self())
-    fprintf(stderr, "created the apf_mds mesh in %f seconds\n", t3-t2);
+    lion_eprint(1, "created the apf_mds mesh in %f seconds\n", t3-t2);
 
   apf::printStats(mesh);
   apf::destroyMesh(simApfMesh);

--- a/phasta/phiotimer.cc
+++ b/phasta/phiotimer.cc
@@ -2,8 +2,9 @@
 #include <pcu_util.h>
 #include <phiotimer.h>
 #include <PCU.h>
+#include <lionPrint.h>
+#include <sstream>
 
-#include <iostream> /* cerr */
 #include <time.h> /* clock_gettime */
 #include <unistd.h> /* usleep */
 
@@ -43,9 +44,13 @@ static size_t phastaio_getCyclesPerMicroSec() {
   phastaio_time(&t1);
   cycles = t1 - t0;
   cpus = ((double)cycles)/(usec);
-  if(!PCU_Comm_Self())
-    std::cerr << "cycles " << cycles << " us " << usec
-         << " cycles per micro second " << cpus << "\n";
+  if(!PCU_Comm_Self()) {
+    std::stringstream ss;
+    ss << "cycles " << cycles << " us " << usec
+       << " cycles per micro second " << cpus << "\n";
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
+  }
   return cpus;
 }
 /*return elapsed time in micro seconds*/
@@ -140,9 +145,13 @@ static void printMinMaxAvgSzt(const char* key, size_t v) {
   size_t max = PCU_Max_SizeT(v);
   size_t tot = PCU_Add_SizeT(v);
   double avg = ((double)tot)/PCU_Comm_Peers();
-  if(!PCU_Comm_Self())
-    std::cerr << getFileName() << "_" << key << "min max avg"
-              << min << " " << max << " " << avg << "\n";
+  if(!PCU_Comm_Self()) {
+    std::stringstream ss;
+    ss << getFileName() << "_" << key << "min max avg"
+       << min << " " << max << " " << avg << "\n";
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
+  }
 }
 
 static void printMinMaxAvgDbl(const char* key, double v) {
@@ -151,7 +160,7 @@ static void printMinMaxAvgDbl(const char* key, double v) {
   double tot = PCU_Add_Double(v);
   double avg = tot/PCU_Comm_Peers();
   if(!PCU_Comm_Self())
-    fprintf(stderr, "%s_%s min max avg %f %f %f\n",
+    lion_eprint(1, "%s_%s min max avg %f %f %f\n",
         getFileName(), key, min, max, avg);
 }
 
@@ -214,14 +223,17 @@ void phastaio_printStats() {
     usleep(us);
     phastaio_time(&t1);
     elapsed = phastaio_time_diff(&t0,&t1);
-    std::cerr << us << " us measured as " << elapsed << "us\n";
+    std::stringstream ss;
+    ss << us << " us measured as " << elapsed << "us\n";
+    std::string s = ss.str();
+    lion_eprint(1,"%s",s.c_str());
   }
   for(int chefFile=0; chefFile<NUM_PHASTAIO_MODES; chefFile++) {
     size_t totalus = 0;
     size_t totalbytes = 0;
     phastaio_setfile(chefFile);
     if(!PCU_Comm_Self())
-      fprintf(stderr, "phastaio_filename %s\n", getFileName());
+      lion_eprint(1, "phastaio_filename %s\n", getFileName());
     int reads = PCU_Max_Int((int)phastaio_getReads());
     if(reads) {
       totalus += phastaio_getReadTime();

--- a/phasta/phstream.cc
+++ b/phasta/phstream.cc
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include "phstream.h"
 #include <mpi.h>
 
@@ -24,7 +25,7 @@ namespace {
     (void) t;
 #if PHSTREAM_TIMERS_ON==1
     if( isRankZero() )
-      fprintf(stderr, "%s %f seconds\n", key, t);
+      lion_eprint(1, "%s %f seconds\n", key, t);
 #endif
   }
 }
@@ -128,7 +129,7 @@ void whichStream(const char* name, bool& isR, bool& isG) {
 }
 
 void writeUnknown(const char* fname) {
-  fprintf(stderr,
+  lion_eprint(1,
       "ERROR %s type of stream %s is unknown... exiting\n",
       __func__, fname);
 }

--- a/phasta/threshold.cc
+++ b/phasta/threshold.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMDS.h>
 #include <apfMesh2.h>
@@ -26,6 +27,7 @@ int main(int argc, char** argv)
   gmi_register_sim();
 #endif
   gmi_register_mesh();
+  lion_set_verbosity(1);
   ph::Input in;
   apf::Mesh2* m = apf::loadMdsMesh(argv[1], argv[2]);
   m->verify();
@@ -49,7 +51,7 @@ int main(int argc, char** argv)
     total_volume += process_element(x, sol);
   }
   m->end(it);
-  printf("volume %f\n", total_volume);
+  lion_oprint(1,"volume %f\n", total_volume);
   m->destroyNative();
   apf::destroyMesh(m);
 #ifdef HAVE_SIMMETRIX

--- a/pumi/pumi_field.cc
+++ b/pumi/pumi_field.cc
@@ -14,6 +14,7 @@
 #include "apfNumbering.h"
 #include <pcu_util.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib> // for malloc and free
 
 //************************************
@@ -466,13 +467,13 @@ void pumi_field_verify(pMesh m, pField f, pOwnership shr)
 
   if (!pumi_rank()) // master
   {
-    printf("  - verifying fields: ");
+    lion_oprint(1,"  - verifying fields: ");
     for (size_t nf = 0; nf < fields.size(); ++nf)
     {
-      printf("%s", getName(fields[nf]));
-      if (nf<fields.size()-1) printf(", ");      
+      lion_oprint(1,"%s", getName(fields[nf]));
+      if (nf<fields.size()-1) lion_oprint(1,", ");
     }
-    printf("\n");
+    lion_oprint(1,"\n");
   }
 
   std::set<pField> mismatch_fields;
@@ -498,12 +499,12 @@ void pumi_field_verify(pMesh m, pField f, pOwnership shr)
   {
     if (!PCU_Comm_Self())
     for (std::set<pField>::iterator it=mismatch_fields.begin(); it!=mismatch_fields.end(); ++it)
-      printf("%s: \"%s\" DOF mismatch over remote/ghost copies\n", __func__, getName(*it));
+      lion_oprint(1,"%s: \"%s\" DOF mismatch over remote/ghost copies\n", __func__, getName(*it));
   }
   else
   {
     if (!PCU_Comm_Self())
-      printf("%s: no DOF mismatch\n", __func__);
+      lion_oprint(1,"%s: no DOF mismatch\n", __func__);
   }
 }
 

--- a/pumi/pumi_geom.cc
+++ b/pumi/pumi_geom.cc
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <cstring>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include "GenIterator.h"
 
 gModel::gModel(gmi_model* model) : TagHolder() 
@@ -59,12 +60,12 @@ pGeom pumi_geom_load(const char* filename, const char* model_type, void (*geom_l
   }
   else
   {
-    if (!pumi_rank()) std::cerr<<"[PUMI ERROR] unsupported model type "<<model_type<<"\n";
+    if (!pumi_rank()) lion_eprint(1,"[PUMI ERROR] unsupported model type %s\n",model_type);
     return NULL;
   }
 
   if (!PCU_Comm_Self() && filename)
-    printf("model %s loaded in %f seconds\n", filename, PCU_Time() - t0);
+    lion_oprint(1,"model %s loaded in %f seconds\n", filename, PCU_Time() - t0);
 
   return pumi::instance()->model;
 }

--- a/pumi/pumi_ghost.cc
+++ b/pumi/pumi_ghost.cc
@@ -15,6 +15,7 @@
 #include <map>
 #include <set>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 #include "apf.h"
@@ -436,7 +437,7 @@ void pumi_ghost_create(pMesh m, Ghosting* plan)
     apf::freeze(*fit);    
 
   if (!PCU_Comm_Self())
-    printf("mesh ghosted in %f seconds\n", PCU_Time()-t0);
+    lion_oprint(1,"mesh ghosted in %f seconds\n", PCU_Time()-t0);
 }
 
 // *********************************************************
@@ -840,7 +841,7 @@ void pumi_ghost_createLayer (pMesh m, int brg_dim, int ghost_dim, int num_layer,
 // STEP 3: perform ghosting
 // ********************************************
   if (!PCU_Comm_Self())
-    printf("ghosting plan computed in %f seconds\n", PCU_Time()-t0);
+    lion_oprint(1,"ghosting plan computed in %f seconds\n", PCU_Time()-t0);
 
   pumi_ghost_create(m, plan);
 }

--- a/pumi/pumi_mesh.cc
+++ b/pumi/pumi_mesh.cc
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <map>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include "apf.h"
 #include "apfShape.h"
@@ -293,7 +294,7 @@ pMesh pumi_mesh_loadAll(pGeom g, const char* filename, bool stitch_link)
     pumi::instance()->mesh = apf::loadSerialMdsMesh(g->getGmi(), filename); 
     merge_comm(prevComm);
     if (!PCU_Comm_Self())
-      printf("serial mesh %s loaded in %f seconds\n", filename, PCU_Time() - t0);
+      lion_oprint(1,"serial mesh %s loaded in %f seconds\n", filename, PCU_Time() - t0);
   }
 
   if (pumi_size()>1 && stitch_link) 

--- a/pumi/pumi_sys.cc
+++ b/pumi/pumi_sys.cc
@@ -9,6 +9,7 @@
 *******************************************************************************/
 #include <PCU.h>
 #include "pumi.h"
+#include <lionPrint.h>
 #include <mpi.h>
 
 //************************************
@@ -49,7 +50,7 @@ void pumi_printSys()
   if (PCU_Comm_Self()) return;
   struct utsname u;
   if (uname(&u) == 0)
-    printf("[%s] %s %s %s %s %s\n\n",
+    lion_oprint(1,"[%s] %s %s %s %s %s\n\n",
            __func__, u.sysname, u.nodename, u.release, u.version, u.machine);
   fflush(stdout);
 }
@@ -111,7 +112,7 @@ void pumi_printTimeMem(const char* msg, double time, double memory)
 {
   if (!PCU_Comm_Self())
   {
-    printf("%-20s %6.3f sec %7.3f MB \n", msg, time, memory);
+    lion_oprint(1,"%-20s %6.3f sec %7.3f MB \n", msg, time, memory);
     fflush(stdout);
   }
 }

--- a/spr/sprEstimateError.cc
+++ b/spr/sprEstimateError.cc
@@ -6,6 +6,7 @@
  */
 
 #include <PCU.h>
+#include <lionPrint.h>
 
 #include "spr.h"
 
@@ -316,7 +317,7 @@ apf::Field* getSPRSizeField(apf::Field* eps, double adaptRatio)
   estimateError(&e);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    fprintf(stderr,"SPR: error estimated in %f seconds\n",t1-t0);
+    lion_eprint(1,"SPR: error estimated in %f seconds\n",t1-t0);
   return e.size;
 }
 

--- a/spr/sprEstimateTargetError.cc
+++ b/spr/sprEstimateTargetError.cc
@@ -13,6 +13,7 @@
 #include "spr.h"
 
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfMesh.h>
 #include <apfShape.h>
 #include <apfCavityOp.h>
@@ -253,7 +254,7 @@ apf::Field* getTargetSPRSizeField(
   target::estimateError(&e);
   double t1 = PCU_Time();
   if (!PCU_Comm_Self())
-    fprintf(stderr, "SPR (target): error estimated in %f seconds\n",t1-t0);
+    lion_eprint(1, "SPR (target): error estimated in %f seconds\n",t1-t0);
   return e.vtx_size;
 }
 

--- a/stk/apfMeshSTK.cc
+++ b/stk/apfMeshSTK.cc
@@ -150,9 +150,9 @@ static void buildElements(
   while ((e = m->iterate(it))) {
     ModelEntity* me = m->toModel(e);
     if (!models.invMaps[d].count(me)) {
-      std::cerr << "apf::copyMeshToBulk: element in unknown element block, "
-                << "geometry " << m->getModelType(me)
-                << ", " << m->getModelTag(me) << '\n';
+      lion_eprint(1,"apf::copyMeshToBulk: element in unknown element block, "
+                    "geometry %d, %d\n", m->getModelType(me),
+                    m->getModelTag(me));
       continue;
     }
     StkModel* model = models.invMaps[d][me];

--- a/stk/apfSTK.cc
+++ b/stk/apfSTK.cc
@@ -6,6 +6,7 @@
  */
 
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf_stkConfig.h>
 #include "apfAlbany.h"
 #include <apfMesh.h>
@@ -758,14 +759,14 @@ long getStkId(GlobalNumbering* numbers, Node node)
 StkModels* create_sets(Mesh* m, const char* filename) {
   StkModels* sets = new StkModels;
   if (! PCU_Comm_Self())
-    printf("reading association file: %s\n", filename);
+    lion_oprint(1,"reading association file: %s\n", filename);
   static std::string const setNames[3] = {
     "node set", "side set", "elem set"};
   auto d = m->getDimension();
   int dims[3] = {0, d - 1, d};
   std::ifstream f(filename);
   if (!f.good()) {
-    printf("cannot open file: %s\n", filename);
+    lion_oprint(1,"cannot open file: %s\n", filename);
     abort();
   }
   std::string sline;
@@ -777,7 +778,7 @@ StkModels* create_sets(Mesh* m, const char* filename) {
     for (int di = 0; di < 3; ++di)
       if (sline.compare(0, setNames[di].length(), setNames[di]) == 0) sdi = di;
     if (sdi == -1) {
-      printf("invalid association line # %d:\n\t%s\n", lc, sline.c_str());
+      lion_oprint(1,"invalid association line # %d:\n\t%s\n", lc, sline.c_str());
       abort();
     }
     int sd = dims[sdi];
@@ -787,14 +788,14 @@ StkModels* create_sets(Mesh* m, const char* filename) {
     int nents;
     strs >> nents;
     if (!strs) {
-      printf("invalid association line # %d:\n\t%s\n", lc, sline.c_str());
+      lion_oprint(1,"invalid association line # %d:\n\t%s\n", lc, sline.c_str());
       abort();
     }
     for (int ei = 0; ei < nents; ++ei) {
       std::string eline;
       std::getline(f, eline);
       if (!f || !eline.length()) {
-        printf("invalid association after line # %d\n", lc);
+        lion_oprint(1,"invalid association after line # %d\n", lc);
         abort();
       }
       ++lc;
@@ -802,12 +803,12 @@ StkModels* create_sets(Mesh* m, const char* filename) {
       int mdim, mtag;
       strs2 >> mdim >> mtag;
       if (!strs2) {
-        printf("bad associations line # %d:\n\t%s\n", lc, eline.c_str());
+        lion_oprint(1,"bad associations line # %d:\n\t%s\n", lc, eline.c_str());
         abort();
       }
       set->ents.push_back(m->findModelEntity(mdim, mtag));
       if (!set->ents.back()) {
-        printf("no model entity with dim: %d and tag: %d\n", mdim, mtag);
+        lion_oprint(1,"no model entity with dim: %d and tag: %d\n", mdim, mtag);
         abort();
       }
     }

--- a/test/1d.cc
+++ b/test/1d.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <gmi_null.h>
 #include <apfMDS.h>
 #include <apf.h>
@@ -66,6 +67,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_model* g;
   apf::Mesh2* m;
   int nverts = atoi(argv[1]);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,6 +17,7 @@ endfunction(test_exe_func)
 # Mesh validity/statistics utilities
 util_exe_func(verify verify.cc)
 util_exe_func(describe describe.cc)
+test_exe_func(outputcontrol outputcontrol.cc)
 test_exe_func(quality quality.cc)
 test_exe_func(writeVtxPtn writeVtxPtn.cc)
 test_exe_func(verify_2nd_order_shapes verify_2nd_order_shapes.cc)

--- a/test/align.cc
+++ b/test/align.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <pcu_util.h>
 
@@ -91,6 +92,7 @@ int main()
 {
   MPI_Init(0,0);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
   testTriEdge();
   testTetEdge();

--- a/test/aniso_ma_test.cc
+++ b/test/aniso_ma_test.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 #include <stdlib.h>
@@ -46,6 +47,7 @@ int main(int argc, char** argv)
   bool logInterpolation = atoi(argv[3]) > 0 ? true : false;
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   ma::Mesh* m = apf::loadMdsMesh(modelFile,meshFile);
   m->verify();

--- a/test/ansys.cc
+++ b/test/ansys.cc
@@ -3,12 +3,14 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <in .node> <in .elem> <out .dmg> <out .smb>\n", argv[0]);

--- a/test/assert_timing.cc
+++ b/test/assert_timing.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdio>
 #include <cstdlib>
@@ -30,6 +31,7 @@ int main(int argc, char** argv) {
   int opt = atoi(argv[1]);
   MPI_Init(0,0);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   /* i'm avoiding conditionals inside for loops b/c
      i'm paranoid about the timings even though timings
      should not be affected by them at all... */

--- a/test/balance.cc
+++ b/test/balance.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 int main(int argc, char** argv)
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   //load model and mesh
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);

--- a/test/bezierElevation.cc
+++ b/test/bezierElevation.cc
@@ -7,6 +7,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <mth.h>
 #include <mth_def.h>
 #include <pcu_util.h>
@@ -399,6 +400,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   testEdgeElevation();
   testTriElevation();
   testTetElevation();

--- a/test/bezierMesh.cc
+++ b/test/bezierMesh.cc
@@ -6,6 +6,7 @@
 #include <apfMDS.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfDynamicMatrix.h>
 #include <pcu_util.h>
 #include <cstdlib>
@@ -585,6 +586,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   test2D();
   test3DBlended();
   test3DFull();

--- a/test/bezierMisc.cc
+++ b/test/bezierMisc.cc
@@ -10,6 +10,7 @@
 #include <apf.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <mth.h>
 #include <mth_def.h>
 #include <pcu_util.h>
@@ -167,6 +168,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   testNodeIndexing();
   testMatrixInverse();
   PCU_Comm_Free();

--- a/test/bezierRefine.cc
+++ b/test/bezierRefine.cc
@@ -10,6 +10,7 @@
 #include <apf.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 
 #include <math.h>
 #include <pcu_util.h>
@@ -311,6 +312,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   test2D();
   test3D();
   PCU_Comm_Free();

--- a/test/bezierSubdivision.cc
+++ b/test/bezierSubdivision.cc
@@ -7,6 +7,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <mth.h>
 #include <mth_def.h>
 #include <pcu_util.h>
@@ -482,6 +483,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   testEdgeSubdivision();
   testTriSubdivision1();
   testTriSubdivision4();

--- a/test/bezierValidity.cc
+++ b/test/bezierValidity.cc
@@ -10,6 +10,7 @@
 #include <apf.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 
 #include <math.h>
 #include <pcu_util.h>
@@ -407,6 +408,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   test2D();
   test3D();
   PCU_Comm_Free();

--- a/test/box.cc
+++ b/test/box.cc
@@ -4,6 +4,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -61,6 +62,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   verifyArgs(argc, argv);
   getArgs(argv);
   gmi_register_mesh();

--- a/test/collapse.cc
+++ b/test/collapse.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -46,6 +47,7 @@ namespace {
 int main(int argc, char** argv) {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_Protect();
 #ifdef HAVE_SIMMETRIX
   Sim_readLicenseFile(0);

--- a/test/construct.cc
+++ b/test/construct.cc
@@ -5,6 +5,7 @@
 #include <apfConvert.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 int main(int argc, char** argv)
@@ -12,6 +13,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   gmi_register_null();
   int* conn;

--- a/test/convert.cc
+++ b/test/convert.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <MeshSim.h>
 #include <SimPartitionedMesh.h>
 #include <SimUtil.h>
@@ -120,6 +121,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init();
   SimModel_start();
   Sim_readLicenseFile(NULL);

--- a/test/crack_test.cc
+++ b/test/crack_test.cc
@@ -14,6 +14,7 @@
 #include <apfNumbering.h>
 #include <pcu_util.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <vector>
 #include <cassert>
 #include <stdlib.h>
@@ -55,6 +56,7 @@ int main(int argc, char** argv)
   const char* modelFile   = argv[1];
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/create_mis.cc
+++ b/test/create_mis.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <apfShape.h>
 
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/curve_to_bezier.cc
+++ b/test/curve_to_bezier.cc
@@ -6,6 +6,7 @@
 #include <gmi_mesh.h>
 #include <gmi_sim.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <SimUtil.h>
 #include <MeshSim.h>
 #include <SimModel.h>
@@ -15,6 +16,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init();
   SimModel_start();
   Sim_readLicenseFile(0);

--- a/test/curvetest.cc
+++ b/test/curvetest.cc
@@ -5,6 +5,7 @@
 #include <gmi_mesh.h>
 #include <gmi_sim.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <SimUtil.h>
 #include <MeshSim.h>
 #include <SimModel.h>
@@ -192,6 +193,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init();
   SimModel_start();
   Sim_readLicenseFile(0);

--- a/test/degenerateSurfs.cc
+++ b/test/degenerateSurfs.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -37,6 +38,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==5);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/describe.cc
+++ b/test/describe.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -89,6 +90,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/dg_ma_test.cc
+++ b/test/dg_ma_test.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -41,6 +42,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/elmBalance.cc
+++ b/test/elmBalance.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -29,6 +30,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh>\n", argv[0]);

--- a/test/extrude.cc
+++ b/test/extrude.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <maExtrude.h>
 #include <cstdlib>
 #include <iostream>
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <nlayers> <out mesh>\n", argv[0]);

--- a/test/fieldReduce.cc
+++ b/test/fieldReduce.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -163,6 +164,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MPI_Comm_rank(PCU_Get_Comm(), &myrank);
   MPI_Comm_size(PCU_Get_Comm(), &commsize);
 #ifdef HAVE_SIMMETRIX

--- a/test/field_io.cc
+++ b/test/field_io.cc
@@ -4,6 +4,7 @@
 #include <apfShape.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 int main(int argc, char** argv)
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   {
   apf::Mesh2* m = apf::loadMdsMesh(argv[1], argv[2]);

--- a/test/fixDisconnected.cc
+++ b/test/fixDisconnected.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -12,6 +13,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh>\n", argv[0]);

--- a/test/fixlayer.cc
+++ b/test/fixlayer.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/fixshape.cc
+++ b/test/fixshape.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/fusion.cc
+++ b/test/fusion.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <apfZoltan.h>
 #include <pcu_util.h>
@@ -160,6 +161,7 @@ int main( int argc, char* argv[])
   PCU_ALWAYS_ASSERT(argc==2);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   GroupCode code;
   code.model = makeModel();
   code.meshFile = argv[1];

--- a/test/fusion2.cc
+++ b/test/fusion2.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <apfZoltan.h>
 #include <pcu_util.h>
@@ -140,6 +141,7 @@ int main( int argc, char* argv[])
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_ALWAYS_ASSERT(PCU_Comm_Peers() == 2);
   gmi_register_null();
   GroupCode code;

--- a/test/fusion3.cc
+++ b/test/fusion3.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <apfZoltan.h>
 #include <vector>
@@ -283,6 +284,7 @@ int main(int argc, char * argv[])
   PCU_ALWAYS_ASSERT(argc==2);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_model* model = makeModel();
   gmi_write_dmg(model, "made.dmg");
   apf::Mesh2* mesh=apf::loadMdsMesh(model, argv[1]);

--- a/test/gap.cc
+++ b/test/gap.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -30,6 +31,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 5);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <max elm imb> <out prefix>\n", argv[0]);

--- a/test/generate.cc
+++ b/test/generate.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <MeshSim.h>
 #include <SimAdvMeshing.h>
 #include <SimPartitionedMesh.h>
@@ -299,6 +300,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_Protect();
   getConfig(argc,argv);
 

--- a/test/ghost.cc
+++ b/test/ghost.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <pcu_util.h>
 #include <cstdlib>
@@ -78,6 +79,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(modelFile,meshFile);

--- a/test/ghostEdge.cc
+++ b/test/ghostEdge.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <pcu_util.h>
 
@@ -51,6 +52,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(modelFile,meshFile);

--- a/test/ghostMPAS.cc
+++ b/test/ghostMPAS.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <pcu_util.h>
 
@@ -53,6 +54,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(modelFile,meshFile);

--- a/test/gmsh.cc
+++ b/test/gmsh.cc
@@ -4,12 +4,14 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <in .msh> <out .smb>\n", argv[0]);

--- a/test/graphdist.cc
+++ b/test/graphdist.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <dsp.h>
 #include <dspGraphDistance.h>
 #include <cstdlib>
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/hierarchic.cc
+++ b/test/hierarchic.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMDS.h>
 #include <apfMesh2.h>
@@ -194,6 +195,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_ALWAYS_ASSERT(! PCU_Comm_Self());
   gmi_register_mesh();
   apf::Mesh2* m = apf::loadMdsMesh(argv[1], argv[2]);

--- a/test/icesheet.cc
+++ b/test/icesheet.cc
@@ -5,6 +5,7 @@
 #include <apfConvert.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 #include <string.h>
@@ -486,6 +487,7 @@ int main(int argc, char** argv)
 
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   gmi_register_null();
 

--- a/test/inClosureOf_test.cc
+++ b/test/inClosureOf_test.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -20,6 +21,7 @@ int main(int argc, char** argv)
 
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/intrude.cc
+++ b/test/intrude.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <maExtrude.h>
 #include <cstdlib>
 #include <iostream>
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh>\n", argv[0]);

--- a/test/loadPart.cc
+++ b/test/loadPart.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <pcu_util.h>
 
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_ALWAYS_ASSERT(PCU_Comm_Peers() == 1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )

--- a/test/ma_insphere.cc
+++ b/test/ma_insphere.cc
@@ -2,6 +2,7 @@
 #include <maMesh.h>
 #include <gmi_null.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <pcu_util.h>
 
@@ -30,6 +31,7 @@ int main(int argc, char** argv)
 
 	// Test insphere (create a mesh with one tet)
 	PCU_Comm_Init();
+  lion_set_verbosity(1);
 	apf::Vector3 a(0, 0, 0);
 	apf::Vector3 b(-6, 0, 0);
 	apf::Vector3 c(0, -6, 0);

--- a/test/ma_test.cc
+++ b/test/ma_test.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -41,6 +42,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/measureAnisoStats.cc
+++ b/test/measureAnisoStats.cc
@@ -5,6 +5,7 @@
 #include <gmi_mesh.h>
 #include <gmi_null.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 #ifdef HAVE_SIMMETRIX
@@ -41,6 +42,7 @@ int main(int argc, char** argv)
 
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (argc < 5) {
     if (PCU_Comm_Self() == 0) {
       printf("USAGE1: %s <mesh.smb> <output_prefix> <scale field name>"

--- a/test/mixedNumbering.cc
+++ b/test/mixedNumbering.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMDS.h>
 #include <apfMesh2.h>
@@ -49,6 +50,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);
   apf::reorderMdsMesh(m);

--- a/test/mkmodel.cc
+++ b/test/mkmodel.cc
@@ -4,6 +4,7 @@
 #include <gmi_null.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 3 ) {
     if ( !PCU_Comm_Self() )
       printf("Create a discrete geometric model from a mesh\n"

--- a/test/mktopomodel.cc
+++ b/test/mktopomodel.cc
@@ -4,6 +4,7 @@
 #include <gmi_null.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -11,6 +12,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 3 ) {
     if ( !PCU_Comm_Self() )
       printf("Create a topological geometric model from a mesh\n"

--- a/test/moving.cc
+++ b/test/moving.cc
@@ -6,6 +6,7 @@
 #include <maSize.h>
 #include <maMesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <sstream>
 
 static void writeStep(apf::Mesh* m, int i)
@@ -20,6 +21,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 3 ) {
     fprintf(stderr, "Usage: %s <model> <mesh>\n", argv[0]);
     return 0;

--- a/test/nektar_align.cc
+++ b/test/nektar_align.cc
@@ -4,6 +4,7 @@
 #include <apfNumbering.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <vector>
 #include <algorithm>
 #ifdef HAVE_SIMMETRIX
@@ -110,6 +111,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/neper.cc
+++ b/test/neper.cc
@@ -3,12 +3,14 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <in .msh> <out .smb>\n", argv[0]);

--- a/test/newdim.cc
+++ b/test/newdim.cc
@@ -3,11 +3,13 @@
 #include <apfMesh2.h>
 #include <gmi_null.h>
 #include <PCU.h>
+#include <lionPrint.h>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
   gmi_model* model = gmi_load(".null");
   apf::Mesh2* m = apf::makeEmptyMdsMesh(model, 2, false);

--- a/test/osh2smb.cc
+++ b/test/osh2smb.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfOmega_h.h>
 #include <cstdlib>
 
@@ -16,6 +17,7 @@
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (argc != 4) {
     if (PCU_Comm_Self() == 0) {
       std::cout << "\n";

--- a/test/outputcontrol.cc
+++ b/test/outputcontrol.cc
@@ -1,0 +1,29 @@
+#include <lionPrint.h>
+#include <cstdio>
+#include <cassert>
+#include <cstdlib>
+
+int main(int argc, char** argv) {
+  if( argc != 2 ) {
+    fprintf(stderr, "Usage: %s <verbosity level>\n", argv[0]);
+    return 0;
+  }
+  int lvl=atoi(argv[1]);
+  lion_set_verbosity(lvl);
+  lion_oprint(1,"message lvl 1\n");
+  lion_oprint(2,"message lvl 2\n");
+  lion_eprint(3,"message lvl 3\n");
+  lion_set_verbosity(0);
+  int ret = lion_oprint(1,"if you see this message"
+                  "there is a problem and the test"
+                  "has failed\n");
+  if( ret ) return 1;
+  FILE* f = fopen("outputGoesHere.txt","w");
+  lion_set_stdout(f);
+  lion_set_stderr(f);
+  lion_set_verbosity(lvl);
+  lion_oprint(1,"out message lvl 1\n");
+  lion_eprint(1,"err message lvl 1\n");
+  fclose(f);
+  return 0;
+}

--- a/test/ph_adapt.cc
+++ b/test/ph_adapt.cc
@@ -7,6 +7,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_io.h>
 #include <phRestart.h>
 #include <phPartition.h>
@@ -47,6 +48,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/poisson.cc
+++ b/test/poisson.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMDS.h>
 #include <apfBox.h>
@@ -252,6 +253,7 @@ int main(int argc, char** argv) {
   PCU_ALWAYS_ASSERT(argc == 3);
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_ALWAYS_ASSERT(! PCU_Comm_Self());
   int dim = atoi(argv[1]);
   int p = atoi(argv[2]);

--- a/test/ptnParma.cc
+++ b/test/ptnParma.cc
@@ -3,9 +3,11 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfZoltan.h>
 #include <parma.h>
 #include <pumi_version.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -157,7 +159,7 @@ void getConfig(int argc, char** argv)
   approach = argv[6];
   isLocal = atoi(argv[7]);
   if(!PCU_Comm_Self())
-    fprintf(stderr, "INPUTS model %s mesh %s out %s factor %d "
+    lion_eprint(1, "INPUTS model %s mesh %s out %s factor %d "
        "method %s approach %s isLocal %d\n", modelFile, meshFile, outFile,
        partitionFactor, method, approach, isLocal);
 }
@@ -168,8 +170,9 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if( !PCU_Comm_Self() )
-    printf("PUMI version %s Git hash %s\n", pumi_version(), pumi_git_sha());
+    lion_oprint(1, "PUMI version %s Git hash %s\n", pumi_version(), pumi_git_sha());
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();
@@ -178,6 +181,7 @@ int main(int argc, char** argv)
   gmi_register_sim();
 #endif
   gmi_register_mesh();
+  lion_set_verbosity(1);
   getConfig(argc,argv);
   if (PCU_Comm_Self() % partitionFactor)
     mymain(false);

--- a/test/pumi.cc
+++ b/test/pumi.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfZoltan.h>
 #include <pcu_util.h>
 #include <cstdlib>
@@ -87,6 +88,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   pumi_start();
+  lion_set_verbosity(1);
   pumi_printSys();
 
 #if 0

--- a/test/quality.cc
+++ b/test/quality.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfMDS.h>
 #include <apfMesh2.h>
@@ -91,6 +92,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);

--- a/test/refine2x.cc
+++ b/test/refine2x.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfNumbering.h>
 #include <apfShape.h>
 #ifdef HAVE_SIMMETRIX
@@ -85,6 +86,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (argc != 5) {
     if(0==PCU_Comm_Self())
       std::cerr << "usage: " << argv[0] 

--- a/test/render.cc
+++ b/test/render.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -17,6 +18,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/renderClass.cc
+++ b/test/renderClass.cc
@@ -5,6 +5,7 @@
 #include <apfNumbering.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -34,6 +35,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (!(argc == 4 || argc == 5)) {
     if ( !PCU_Comm_Self() ) {
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/render_ascii.cc
+++ b/test/render_ascii.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -15,6 +16,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/reorder.cc
+++ b/test/reorder.cc
@@ -4,6 +4,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -16,6 +17,7 @@
 int main(int argc, char** argv) {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix>\n", argv[0]);

--- a/test/repartition.cc
+++ b/test/repartition.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <apfZoltan.h>
 #include <apfPartition.h>
@@ -95,6 +96,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   gmi_model* g = gmi_load(modelFile);

--- a/test/reposition.cc
+++ b/test/reposition.cc
@@ -3,12 +3,14 @@
 #include <apfMDS.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <maReposition.h>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #if 0
   gmi_register_null();
   gmi_model* model = gmi_load(".null");

--- a/test/rm_extrusion.cc
+++ b/test/rm_extrusion.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <MeshSim.h>
 #include <SimPartitionedMesh.h>
 #include <SimUtil.h>
@@ -89,6 +90,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init();
   SimAdvMeshing_start();
   SimModel_start();

--- a/test/runSimxAnisoAdapt.cc
+++ b/test/runSimxAnisoAdapt.cc
@@ -7,6 +7,7 @@
 #include <apfShape.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 #include "MeshSim.h"
@@ -80,6 +81,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init(); // Call before calling Sim_readLicenseFile
   Sim_readLicenseFile(0);
   SimDiscrete_start(0);  // initialize GeomSim Discrete library

--- a/test/scale.cc
+++ b/test/scale.cc
@@ -4,6 +4,7 @@
 #include <apfShape.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 namespace {
@@ -55,6 +56,7 @@ static void scale_mesh(apf::Mesh2* m, Scale const& s) {
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   if (argc != 8) print_usage(argv);
   const char* gfile = argv[1];

--- a/test/serialize.cc
+++ b/test/serialize.cc
@@ -1,5 +1,6 @@
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfMDS.h>
 #include <gmi_mesh.h>
 #include <crv.h>
@@ -26,6 +27,7 @@ int main( int argc, char* argv[])
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out prefix> <reduction-factor>\n", argv[0]);

--- a/test/shapefun.cc
+++ b/test/shapefun.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 #include <iostream>
@@ -244,6 +245,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
   testP1LineNodeValues();
   testP2LineNodeValues();

--- a/test/shapefun2.cc
+++ b/test/shapefun2.cc
@@ -5,6 +5,7 @@
 #include <apfMesh2.h>
 #include <crv.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 namespace test {
@@ -171,6 +172,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
 
   // put fieldShapes to test here

--- a/test/simZBalance.cc
+++ b/test/simZBalance.cc
@@ -1,4 +1,5 @@
 #include <PCU.h>
+#include <lionPrint.h>
 #include <ma.h>
 #include <MeshSim.h>
 #include <SimUtil.h>
@@ -14,6 +15,7 @@
 static void initialize(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   Sim_readLicenseFile(NULL);
   gmi_sim_start();
   gmi_register_sim();

--- a/test/sim_part.cc
+++ b/test/sim_part.cc
@@ -23,6 +23,7 @@
 
 /* cheap hackish way to get SIM_PARASOLID and SIM_ACIS */
 #include <PCU.h>
+#include <lionPrint.h>
 #include "gmi_sim_config.h"
 #include <gmi_sim.h>
 
@@ -66,6 +67,7 @@ int main(int argc, char **argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_Protect();
   // Initialize PartitionedMesh - this should be the first Simmetrix call
   // Also initializes MPI in parallel

--- a/test/smb2osh.cc
+++ b/test/smb2osh.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apfOmega_h.h>
 #include <cstdlib>
 
@@ -16,6 +17,7 @@
 int main(int argc, char** argv) {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (argc != 4) {
     if (PCU_Comm_Self() == 0) {
       std::cout << "\n";

--- a/test/snap.cc
+++ b/test/snap.cc
@@ -3,6 +3,7 @@
 #include <gmi_sim.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <SimUtil.h>
 #include <MeshSim.h>
 #include <SimModel.h>
@@ -13,6 +14,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   MS_init();
   SimModel_start();
   Sim_readLicenseFile(0);

--- a/test/split.cc
+++ b/test/split.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -76,6 +77,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/spr_test.cc
+++ b/test/spr_test.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -19,6 +20,7 @@ int main(int argc, char** argv)
   const int order = atoi(argv[4]);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   apf::Mesh2* mesh = apf::loadMdsMesh(modelFile, meshFile);
   if (mesh->findTag("coordinates_edg"))

--- a/test/test_scaling.cc
+++ b/test/test_scaling.cc
@@ -6,6 +6,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <samSz.h>
 #include <samElementCount.h>
 
@@ -14,6 +15,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);
   apf::Field* identity_size = samSz::isoSize(m);

--- a/test/test_verify.cc
+++ b/test/test_verify.cc
@@ -4,6 +4,7 @@
 #include <apfMesh2.h>
 #include <gmi_mesh.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <vector>
 #include <sstream>
 #include <pcu_util.h>
@@ -12,6 +13,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   PCU_ALWAYS_ASSERT(argc == 3);
   gmi_register_mesh();
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -372,6 +372,8 @@ mpi_test(fixDisconnected 4
   "${MDIR}/torus.dmg"
   "${MDIR}/4imb/torus.smb"
   "torusDcFix4p/")
+mpi_test(outputcontrol 1
+  ./outputcontrol 2)
 mpi_test(quality 4
   ./quality
   "${MDIR}/torus.dmg"

--- a/test/tetrahedronize.cc
+++ b/test/tetrahedronize.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/torus_ma_test.cc
+++ b/test/torus_ma_test.cc
@@ -4,6 +4,7 @@
 #include <apfMDS.h>
 #include <apfShape.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 class CylindricalShock : public ma::AnisotropicFunction
@@ -48,6 +49,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   ma::Mesh* m = apf::loadMdsMesh(modelFile,meshFile);
   m->verify();

--- a/test/ugrid.cc
+++ b/test/ugrid.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <cstdlib>
 #include <pcu_util.h>
@@ -39,6 +40,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <in .[b8|lb8].ugrid> <out .dmg> <out .smb> <partition factor>\n", argv[0]);

--- a/test/ugridptnstats.cc
+++ b/test/ugridptnstats.cc
@@ -3,6 +3,7 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <pcu_util.h>
 
@@ -20,6 +21,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
   PCU_ALWAYS_ASSERT( 3 == argc );
   const char* ugridfile = argv[1];

--- a/test/uniform.cc
+++ b/test/uniform.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -34,6 +35,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/verify.cc
+++ b/test/verify.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -16,6 +17,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/verify_2nd_order_shapes.cc
+++ b/test/verify_2nd_order_shapes.cc
@@ -5,6 +5,7 @@
 #include <apfShape.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -18,6 +19,7 @@
 int main(int argc, char** argv) {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 2 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <mesh .smb>\n", argv[0]);

--- a/test/verify_convert.cc
+++ b/test/verify_convert.cc
@@ -3,6 +3,7 @@
  * fields, numberings, and tags
  */
 #include <PCU.h>
+#include <lionPrint.h>
 #include <apf.h>
 #include <apfConvert.h>
 #include <apfMDS.h>
@@ -42,6 +43,7 @@ int main(int argc, char* argv[])
 {
   MPI_Init(&argc, &argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_null();
   apf::Mesh* m1 = createMesh();
   apf::Mesh2* m2 = createEmptyMesh();

--- a/test/visualizeAnisoSizes.cc
+++ b/test/visualizeAnisoSizes.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <gmi_null.h>
 #include <PCU.h>
+#include <lionPrint.h>
 
 #ifdef HAVE_SIMMETRIX
 #include <ph.h>
@@ -59,6 +60,7 @@ int main(int argc, char** argv)
 
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if (argc < 8) {
     if (PCU_Comm_Self() == 0) {
       printf("USAGE1: %s <mesh.smb> <output_prefix> <scale field name>"

--- a/test/viz.cc
+++ b/test/viz.cc
@@ -4,6 +4,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include "../viz/viz.h"
 
@@ -37,6 +38,7 @@ int main(int argc, char** argv)
   MPI_Init_thread(&argc,&argv,MPI_THREAD_MULTIPLE,&provided);
   PCU_ALWAYS_ASSERT(provided==MPI_THREAD_MULTIPLE);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(modelFile,meshFile);

--- a/test/vtxBalance.cc
+++ b/test/vtxBalance.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -31,6 +32,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh>\n", argv[0]);

--- a/test/vtxEdgeElmBalance.cc
+++ b/test/vtxEdgeElmBalance.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
 #include <SimUtil.h>
@@ -46,6 +47,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 6);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 6 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh> <edge weight> <tgt imb>\n", argv[0]);

--- a/test/vtxElmBalance.cc
+++ b/test/vtxElmBalance.cc
@@ -4,6 +4,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib>
 
@@ -35,6 +36,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc == 4);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <out mesh>\n", argv[0]);

--- a/test/vtxElmMixedBalance.cc
+++ b/test/vtxElmMixedBalance.cc
@@ -3,6 +3,7 @@
 #include <gmi_mesh.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -18,6 +19,7 @@ int main(int argc, char** argv)
   const char* meshFile = argv[2];
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/test/writeIPFieldTest.cc
+++ b/test/writeIPFieldTest.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apf.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 
 int main(int argc, char** argv)
@@ -10,6 +11,7 @@ int main(int argc, char** argv)
   PCU_ALWAYS_ASSERT(argc==3);
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   apf::Mesh2* m = apf::loadMdsMesh(argv[1],argv[2]);
   m->verify();

--- a/test/writePart.cc
+++ b/test/writePart.cc
@@ -3,12 +3,14 @@
 #include <apfMDS.h>
 #include <apfMesh2.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <cstdlib>
 
 int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 5 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <part id> <out mesh file>\n", argv[0]);

--- a/test/writeVtxPtn.cc
+++ b/test/writeVtxPtn.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #include <pcu_util.h>
 #include <cstdlib>
@@ -34,6 +35,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   gmi_register_mesh();
   getConfig(argc,argv);
   apf::Mesh2* m = apf::loadMdsMesh(modelFile,meshFile);

--- a/test/zbalance.cc
+++ b/test/zbalance.cc
@@ -6,6 +6,7 @@
 #include <gmi_mesh.h>
 #include <parma.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <pcu_util.h>
 #include <cstdlib> // exit and EXIT_FAILURE
 #ifdef HAVE_SIMMETRIX
@@ -20,6 +21,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
   if ( argc != 4 ) {
     if ( !PCU_Comm_Self() )
       printf("Usage: %s <model> <mesh> <output mesh prefix>\n", argv[0]);

--- a/test/zsplit.cc
+++ b/test/zsplit.cc
@@ -3,6 +3,7 @@
 #include <apfMesh2.h>
 #include <apfMDS.h>
 #include <PCU.h>
+#include <lionPrint.h>
 #include <parma.h>
 #ifdef HAVE_SIMMETRIX
 #include <gmi_sim.h>
@@ -78,6 +79,7 @@ int main(int argc, char** argv)
 {
   MPI_Init(&argc,&argv);
   PCU_Comm_Init();
+  lion_set_verbosity(1);
 #ifdef HAVE_SIMMETRIX
   MS_init();
   SimModel_start();

--- a/zoltan/apfZoltan.cc
+++ b/zoltan/apfZoltan.cc
@@ -9,6 +9,7 @@
 #include "apfZoltanMesh.h"
 #include <apfPartition.h>
 #include <PCU.h>
+#include <lionPrint.h>
 
 namespace apf {
 
@@ -36,7 +37,7 @@ class ZoltanSplitter : public Splitter
       }
       double t1 = PCU_Time();
       if (!PCU_Comm_Self())
-        fprintf(stdout, "planned Zoltan split factor %d to target"
+        lion_oprint(1, "planned Zoltan split factor %d to target"
             " imbalance %f in %f seconds\n", multiple, tolerance, t1 - t0);
       return plan;
     }
@@ -57,13 +58,13 @@ class ZoltanBalancer : public Balancer
       double t0 = PCU_Time();
       Migration* plan = bridge.run(weights, tolerance, 1);
       if (!PCU_Comm_Self())
-        fprintf(stdout, "planned Zoltan balance to target "
+        lion_oprint(1, "planned Zoltan balance to target "
             "imbalance %f in %f seconds\n",
             tolerance, PCU_Time() - t0);
       bridge.mesh->migrate(plan);
       double t1 = PCU_Time();
       if (!PCU_Comm_Self())
-        printf("Zoltan balanced to %f in %f seconds\n",
+        lion_oprint(1,"Zoltan balanced to %f in %f seconds\n",
             tolerance, t1-t0);
     }
   private:

--- a/zoltan/apfZoltan.h
+++ b/zoltan/apfZoltan.h
@@ -81,7 +81,7 @@ class MeshTag;
               multiply the part ids in the resulting apf::Migration
               accordingly */
 Splitter* makeZoltanSplitter(Mesh* mesh, int method, int approach,
-    bool debug = true, bool sync = true);
+    bool debug = false, bool sync = true);
 
 /** \brief Make a Zoltan Splitter object
   \details the resulting splitter will apply Zoltan
@@ -91,7 +91,7 @@ Splitter* makeZoltanSplitter(Mesh* mesh, int method, int approach,
   \param debug print the full Zoltan configuration when splitting
   */
 Splitter* makeZoltanGlobalSplitter(Mesh* mesh, int method, int approach,
-    bool debug = true);
+    bool debug = false);
 
 /** \brief Make a Zoltan Balancer object
   \details this Balancer will apply Zoltan to the global mesh
@@ -103,7 +103,7 @@ Splitter* makeZoltanGlobalSplitter(Mesh* mesh, int method, int approach,
   \param approach select from apf::ZoltanApproach
   \param debug print the full Zoltan configuration */
 Balancer* makeZoltanBalancer(Mesh* mesh, int method, int approach,
-    bool debug = true);
+    bool debug = false);
 
 /** \brief Tag global ids of opposite elements to boundary faces
   \details this function creates a LONG tag of one value

--- a/zoltan/apfZoltanCallbacks.cc
+++ b/zoltan/apfZoltanCallbacks.cc
@@ -12,6 +12,7 @@
 #include <PCU.h>
 #include <metis.h>
 #include <pcu_util.h>
+#include <lionPrint.h>
 #include <cstdlib>
 #include <iostream>
 
@@ -34,8 +35,7 @@ static int setZoltanLbMethod(struct Zoltan_Struct* ztn, ZoltanMesh* zb)
       Zoltan_Set_Param(ztn, "GRAPH_PACKAGE", "PARMETIS"); // instead of PHG
       break;
     default:
-      std::cout << "ERROR " << __func__ << " Invalid LB_METHOD "
-        << zb->method << "\n";
+      lion_oprint(1,"ERROR %s Invalid LB_METHOD %d\n",__func__, zb->method);
       return 1;
   }
   Zoltan_Set_Param(ztn, "LB_METHOD", lbMethod.c_str());
@@ -65,8 +65,7 @@ static int setZoltanLbApproach(struct Zoltan_Struct* ztn, ZoltanMesh* zb)
     case REFINE_KWAY:
       pMethod = "RefineKway"; break;
     default:
-      std::cout << "ERROR " << __func__ << " Invalid LB_Approach "
-        << zb->approach << "\n";
+      lion_oprint(1,"ERROR %s Invalid LB_Approach %d\n",__func__, zb->approach);
       return 1;
   }
   Zoltan_Set_Param(ztn, "LB_APPROACH", ptnAp.c_str());
@@ -267,7 +266,7 @@ ZoltanData::ZoltanData(ZoltanMesh* zb_) : zb(zb_)
   float ver;
   int ret = Zoltan_Initialize(0,0,&ver);
   if (ZOLTAN_OK != ret) {
-    fprintf(stderr, "ERROR: Zoltan initialization failed\n");
+    lion_eprint(1, "ERROR: Zoltan initialization failed\n");
     exit(1);
   }
   MPI_Comm comm;
@@ -374,7 +373,7 @@ void ZoltanData::ptn()
       &export_lids, &export_procs, &export_to_part);
   if( ZOLTAN_OK != ret ) {
     if( 0 == PCU_Comm_Self() )
-      fprintf(stderr, "ERROR Zoltan partitioning failed\n");
+      lion_eprint(1, "ERROR Zoltan partitioning failed\n");
     exit(EXIT_FAILURE);
   }
   //writeZoltanDbgFiles(ztn, "kddParted");


### PR DESCRIPTION
This PR attempts to satisfy [PUMI's compliance](https://github.com/xsdk-project/xsdk-issues/issues/67) with [XSDK policy M11](https://figshare.com/articles/xSDK_Community_Package_Policies/4495136):

> M11​. No package should have hardwired print or I/O statements that cannot be turned off through a
programmatic interface ; output should never be hard-wired to stdout or stderr. It is recommended
that packages provide a way for users to turn on output and allow them to direct where it goes. Also,
packages may print to stdout by default but only on one process (i.e., root rank “0”). But packages
may also be completely silent by default (and require that users turn on outputting in the appropriate
way).

In the `lion` directory (previously was used for compressing io) is an interface for conditional print statements:
https://github.com/cwsmith/core/blob/7d3e2e2fc195568ecabe3990017e68e12e9dd7b0/lion/lionPrint.h

Please let me know what you think of this approach/design.  I'm open to suggestions.