### PR TITLE
Jc copy data

### DIFF
--- a/apf/apfConvert.cc
+++ b/apf/apfConvert.cc
@@ -21,7 +21,7 @@ class Converter
       inMesh = a;
       outMesh = b;
     }
-    void run()
+    void run(bool copy_data=true)
     {
       createVertices();
       createEntities();
@@ -31,12 +31,15 @@ class Converter
         for (int i = 0; i <= inMesh->getDimension(); ++i)
           createMatches(i);
       convertQuadratic();
-      convertFields();
-      convertNumberings();
-      convertGlobalNumberings();
-      // this must be called after anything that might create tags e.g. fields
-      // or numberings to avoid problems with tag duplication
-      convertTags();
+      if (copy_data)
+      {
+        convertFields();
+        convertNumberings();
+        convertGlobalNumberings();
+        // this must be called after anything that might create tags e.g. fields
+        // or numberings to avoid problems with tag duplication
+        convertTags();
+      }
       outMesh->acceptChanges();
     }
     ModelEntity* getNewModelFromOld(ModelEntity* oldC)
@@ -389,10 +392,10 @@ class Converter
     std::map<MeshEntity*,MeshEntity*> newFromOld;
 };
 
-void convert(Mesh *in, Mesh2 *out)
+void convert(Mesh *in, Mesh2 *out, bool copy_data/* =true */)
 {
   Converter c(in,out);
-  c.run();
+  c.run(copy_data);
 }
 
 }

--- a/apf/apfConvert.h
+++ b/apf/apfConvert.h
@@ -25,7 +25,7 @@ class MeshEntity;
   implements apf::Mesh2 by using information from an implementation
   of apf::Mesh. This is a fully scalable parallel mesh conversion
   tool. */
-void convert(Mesh *in, Mesh2 *out);
+void convert(Mesh *in, Mesh2 *out, bool copy_data=true);
 
 /** \brief a map from global ids to vertex objects */
 typedef std::map<int, MeshEntity*> GlobalToVert;

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -174,7 +174,7 @@ class MeshMDS : public Mesh2
       isMatched = isMatched_;
       ownsModel = true;
     }
-    MeshMDS(gmi_model* m, Mesh* from)
+    MeshMDS(gmi_model* m, Mesh* from, bool copy_data=true)
     {
       init(apf::getLagrange(1));
       mds_id cap[MDS_TYPES];
@@ -190,7 +190,7 @@ class MeshMDS : public Mesh2
       mesh = mds_apf_create(m,d,cap);
       isMatched = from->hasMatching();
       ownsModel = true;
-      apf::convert(from,this);
+      apf::convert(from,this, copy_data);
     }
     MeshMDS(gmi_model* m, const char* pathname)
     {
@@ -767,9 +767,9 @@ Mesh2* makeEmptyMdsMesh(gmi_model* model, int dim, bool isMatched)
   return m;
 }
 
-Mesh2* createMdsMesh(gmi_model* model, Mesh* from)
+Mesh2* createMdsMesh(gmi_model* model, Mesh* from, bool copy_data/* =true */)
 {
-  return new MeshMDS(model, from);
+  return new MeshMDS(model, from, copy_data);
 }
 
 Mesh2* loadSerialMdsMesh(gmi_model* model, const char* meshfile)

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -81,8 +81,10 @@ Mesh2* loadSerialMdsMesh(gmi_model* model, const char* meshfile);
 
 /** \brief create an MDS mesh from an existing mesh
   \param from the mesh to copy
-  \details this function uses apf::convert to copy any apf::Mesh */
-Mesh2* createMdsMesh(gmi_model* model, Mesh* from);
+  \details this function uses apf::convert to copy any apf::Mesh,
+           Fields/Numberings/Tags are copied if copy_data is true (default)
+  */
+Mesh2* createMdsMesh(gmi_model* model, Mesh* from, bool copy_data=true);
 
 /** \brief apply adjacency-based reordering
   \param t Optional user-defined ordering of the vertices.

--- a/test/verify_convert.cc
+++ b/test/verify_convert.cc
@@ -46,6 +46,8 @@ int main(int argc, char* argv[])
   PCU_Comm_Init();
   lion_set_verbosity(1);
   gmi_register_null();
+
+  // create meshes and write data to one of them
   apf::Mesh* m1 = createMesh();
   apf::Mesh2* m2 = createEmptyMesh();
   // create field on m1
@@ -88,6 +90,8 @@ int main(int argc, char* argv[])
     if (!(std::abs(uval - 2 * double(val)) < 1E-15)) return 1;
   }
   m1->end(it);
+
+
   // copy m1 to m2
   apf::convert(m1, m2);
   m2->verify();
@@ -129,11 +133,30 @@ int main(int argc, char* argv[])
     ++count;
   }
   m2->end(it);
+
+  // check that not transfering Fields/Numberings/Tags also works
+  apf::Mesh2* m3 = createEmptyMesh();
+  apf::convert(m1, m3, false);
+  m3->verify();
+
+  assert(!m3->findNumbering(apf::getName(numWithField)));
+  assert(!m3->findNumbering(apf::getName(numNoField)));
+  assert(!m3->findGlobalNumbering(apf::getName(globalNumWithField)));
+  assert(!m3->findGlobalNumbering(apf::getName(globalNumNoField)));
+  assert(!m3->findNumbering(apf::getName(numWithField)));
+  assert(!m3->findGlobalNumbering(apf::getName(globalNumWithField)));
+  assert(!m3->findTag("intTag"));
+
+
+
+  // cleanup
   delete func;
   m1->destroyNative();
   m2->destroyNative();
+  m3->destroyNative();
   apf::destroyMesh(m1);
   apf::destroyMesh(m2);
+  apf::destroyMesh(m3);
   PCU_Comm_Free();
   MPI_Finalize();
   return 0;


### PR DESCRIPTION
This change adds an optional argument to `apf::convert` (and functions that call `apf::convert`) that controls whether Fields/Numberings/GlobalNumberings/Tags are copied.  The default value is true, to preserve the original behavior.

This behavior is useful for doing an in-memory copy of the mesh data structure only.