### PR TITLE
Adding newly created file to pkg_tribits.cmake

### DIFF
--- a/ma/pkg_tribits.cmake
+++ b/ma/pkg_tribits.cmake
@@ -30,6 +30,7 @@ set(SOURCES
   maSplits.cc
   maFaceSplit.cc
   maDoubleSplitCollapse.cc
+  maSingleSplitCollapse.cc
   maFaceSplitCollapse.cc
   maShortEdgeRemover.cc
   maVertRemover.cc


### PR DESCRIPTION
This fixes linking errors that we are experiencing in Albany (see SNLComputation/Albany#459).