### PR TITLE
More general entity-type counting, expose the NoSharing type through the API for external usage

### DIFF
--- a/apf/apf.cc
+++ b/apf/apf.cc
@@ -21,6 +21,7 @@
 #include "apfNumberingClass.h"
 #include <cstdio>
 #include <cstdlib>
+#include <PCU.h>
 #include <pcu_util.h>
 #include <lionPrint.h>
 
@@ -138,6 +139,46 @@ Mesh* getMesh(Field* f)
 bool hasEntity(Field* f, MeshEntity* e)
 {
   return f->getData()->hasEntity(e);
+}
+
+int countLocalNodes(Field* f, Sharing* shr)
+{
+  Mesh * msh = getMesh(f);
+  FieldShape * shp = getShape(f);
+  return countLocalNodes(msh,shp,shr);
+}
+
+int countLocalNodes(Mesh* m, FieldShape * shp, Sharing * shr)
+{
+  // if shr is NULL, the default behavior of
+  //  countEntitiesOfType is to count ALL
+  //  entities on the local part of type tp
+  int nds = 0;
+  for(int tp = Mesh::VERTEX; tp != Mesh::TYPES; ++tp)
+    nds += countEntitiesOfType(m,tp,shr) * shp->countNodesOn(tp);
+  return nds;
+}
+
+int countGlobalNodes(Field* f, Sharing* shr)
+{
+  Mesh * msh = getMesh(f);
+  FieldShape * shp = getShape(f);
+  return countGlobalNodes(msh,shp,shr);
+}
+
+int countGlobalNodes(Mesh* m, FieldShape* shp, Sharing* shr)
+{
+  bool del = false;
+  if(shr == NULL)
+  {
+    shr = getSharing(m);
+    del = true;
+  }
+  int lcl_nds = countLocalNodes(m,shp,shr);
+  int gbl_nds = PCU_Add_Int(lcl_nds);
+  if(del)
+    delete shr;
+  return gbl_nds;
 }
 
 const char* getName(Field* f)

--- a/apf/apf.h
+++ b/apf/apf.h
@@ -204,6 +204,24 @@ Mesh* getMesh(Field* f);
   */
 bool hasEntity(Field* f, MeshEntity* e);
 
+/** \brief Count all field nodes owned according to shr, on all mesh
+    entities on the local part, default is all to count every node,
+    even those on owned entities
+  */
+int countLocalNodes(Field* f, Sharing* shr = NULL);
+/** \brief same as countLocalNodes but you don't need to allocate a field
+  */
+int countLocalNodes(Mesh* m, FieldShape* shp, Sharing* shr = NULL);
+
+/** \brief Count all field nodes owned according to shr, on all mesh
+    entities on all parts in PCU_COMM_WORLD, default is to use the
+    NormalSharing to define ownership.
+  */
+int countGlobalNodes(Field* f, Sharing* shr = NULL);
+/** \brief same as countGlobalNodes but you don't need to allocate a field
+  */
+int countGlobalNodes(Mesh* m, FieldShape* shp, Sharing* shr = NULL);
+
 /** \brief Get the name of a Field.
   *
   * \details Both for use convenience and for technical reasons

--- a/apf/apf.h
+++ b/apf/apf.h
@@ -682,7 +682,7 @@ void synchronize(Field* f, Sharing* shr = 0);
   */
 void accumulate(Field* f, Sharing* shr = 0, bool delete_shr = false);
 
-/** \brief Apply a reudction operator along partition boundaries
+/** \brief Apply a reduction operator along partition boundaries
   \details Using the copies described by an apf::Sharing object, applied
   the specified operation pairwise to the values of the field on each
   partition.  No guarantee is made about hte order of the pairwise

--- a/apf/apfMesh.cc
+++ b/apf/apfMesh.cc
@@ -676,13 +676,16 @@ MeshEntity* getEdgeVertOppositeVert(Mesh* m, MeshEntity* edge, MeshEntity* v)
   return ev[0];
 }
 
-int countEntitiesOfType(Mesh* m, int type)
+
+int countEntitiesOfType(Mesh* m, int type, Sharing * shr)
 {
+  if(shr == NULL)
+    shr = getNoSharing();
   MeshIterator* it = m->begin(Mesh::typeDimension[type]);
   MeshEntity* e;
   int count = 0;
   while ((e = m->iterate(it)))
-    if (m->getType(e)==type)
+    if (m->getType(e)==type && shr->isOwned(e))
       ++count;
   m->end(it);
   return count;
@@ -995,6 +998,36 @@ bool MatchedSharing::isShared(MeshEntity* e) {
       return true;
   return false;
 }
+
+// treat all entities as if they are not shared,
+//  used to count all local entities instead of
+//  all owned entities as the default
+// The ONLY justification for this being a
+//  singleton is that it is essentially a functor
+//  at this point, as it retains no state, so there
+//  only ever needs to be a single instance of this
+struct NoSharing : public Sharing
+{
+private:
+  static NoSharing * instance;
+  NoSharing() {}
+  ~NoSharing() {}
+public:
+  static NoSharing * Instance()
+  {
+    if(instance == NULL)
+      instance = new NoSharing;
+    return instance;
+  }
+  virtual int getOwner(MeshEntity*) { return PCU_Comm_Self(); }
+  virtual bool isOwned(MeshEntity*) { return true; }
+  virtual void getCopies(MeshEntity*,CopyArray&) { }
+  virtual bool isShared(MeshEntity*) { return false; }
+};
+NoSharing * NoSharing::instance = NULL;
+
+// obfuscate the singleton just a bit
+Sharing* getNoSharing() { return NoSharing::Instance(); }
 
 Sharing* getSharing(Mesh* m)
 {

--- a/apf/apfMesh.h
+++ b/apf/apfMesh.h
@@ -430,9 +430,6 @@ MeshEntity* getEdgeVertOppositeVert(Mesh* m, MeshEntity* edge, MeshEntity* v);
 void getBridgeAdjacent(Mesh* m, MeshEntity* origin,
     int bridgeDimension, int targetDimension, Adjacent& result);
 
-/** \brief count all on-part entities of one topological type */
-int countEntitiesOfType(Mesh* m, int type);
-
 /** \brief return true if the topological type is a simplex */
 bool isSimplex(int type);
 
@@ -516,12 +513,20 @@ private:
   std::map<int, size_t> countMap;
 };
 
+Sharing* getNoSharing();
+
 /** \brief create a default sharing object for this mesh
   \details for normal meshes, the sharing object just
   describes remote copies. For matched meshes, the
   sharing object describes matches for matched entities
   and remote copies for other entities */
 Sharing* getSharing(Mesh* m);
+
+/** \brief count all on-part entities of one topological type,
+    \details if a sharing is provided, only 'owned' entities of
+    the specified type are counted, otherwise all on-part entities
+    are counted */
+int countEntitiesOfType(Mesh* m, int type, Sharing * shr = NULL);
 
 /** \brief map from triangle edge order to triangle vertex order */
 extern int const tri_edge_verts[3][2];

--- a/apf/apfNumbering.cc
+++ b/apf/apfNumbering.cc
@@ -221,14 +221,6 @@ void synchronize(Numbering * n, Sharing* shr, bool delete_shr)
   synchronizeFieldData<int>(n->getData(), shr, delete_shr);
 }
 
-struct NoSharing : public Sharing
-{
-  int getOwner(MeshEntity*) {return PCU_Comm_Self();} 
-  bool isOwned(MeshEntity*) {return true;}
-  virtual void getCopies(MeshEntity*, CopyArray&) {}
-  bool isShared(MeshEntity*) {return false;}
-};
-
 Numbering* numberNodes(
     Mesh* mesh,
     const char* name,
@@ -258,14 +250,13 @@ Numbering* numberNodes(
   return n;
 }
 
-Numbering* numberOwnedDimension(Mesh* mesh, const char* name, int dim,
-    Sharing* shr)
+Numbering* numberOwnedDimension(Mesh* mesh, const char* name, int dim, Sharing * shr)
 {
-  bool delete_shr=false;
-  if (!shr) 
+  bool delete_shr = false;
+  if (!shr)
   {
     shr = getSharing(mesh);
-    delete_shr=true;
+    delete_shr = true;
   }
   return numberNodes(mesh, name, getConstant(dim), shr, delete_shr);
 }
@@ -273,8 +264,8 @@ Numbering* numberOwnedDimension(Mesh* mesh, const char* name, int dim,
 Numbering* numberOverlapDimension(Mesh* mesh, const char* name, int dim)
 {
   FieldShape* s = getConstant(dim);
-  Sharing* shr = new NoSharing();
-  return numberNodes(mesh, name, s, shr, true);
+  Sharing* shr = getNoSharing();
+  return numberNodes(mesh, name, s, shr, false);
 }
 
 Numbering* numberElements(Mesh* mesh, const char* name)
@@ -286,8 +277,7 @@ Numbering* numberOverlapNodes(Mesh* mesh, const char* name, FieldShape* s)
 {
   if (!s)
     s = mesh->getShape();
-  Sharing* shr = new NoSharing();
-  return numberNodes(mesh, name, s, shr, true);
+  return numberNodes(mesh, name, s, getNoSharing(), false);
 }
 
 Numbering* numberOwnedNodes(

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ test_exe_func(quality quality.cc)
 test_exe_func(writeVtxPtn writeVtxPtn.cc)
 test_exe_func(verify_2nd_order_shapes verify_2nd_order_shapes.cc)
 test_exe_func(verify_convert verify_convert.cc)
+test_exe_func(count_entities count_entities.cc)
 
 # Geometric model utilities
 if(ENABLE_SIMMETRIX)

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -35,10 +35,10 @@ mpi_test(qr_test 1 ./qr)
 mpi_test(base64 1 ./base64)
 mpi_test(tensor_test 1 ./tensor)
 mpi_test(verify_convert 1 ./verify_convert)
-mpi_test(count_entities_serial 1
+mpi_test(count_serial 1
          ./count_entities
          "${MESHES}/cube/pumi11/cube.smb")
-mpi_test(count_entities_parallel 2
+mpi_test(count_parallel 2
          ./count_entities
          "${MESHES}/cube/pumi670/2/cube.smb")
 mpi_test(test_integrator 1

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -35,6 +35,12 @@ mpi_test(qr_test 1 ./qr)
 mpi_test(base64 1 ./base64)
 mpi_test(tensor_test 1 ./tensor)
 mpi_test(verify_convert 1 ./verify_convert)
+mpi_test(count_entities_serial 1
+         ./count_entities
+         "${MESHES}/cube/pumi11/cube.smb")
+mpi_test(count_entities_parallel 2
+         ./count_entities
+         "${MESHES}/cube/pumi670/2/cube.smb")
 mpi_test(test_integrator 1
          ./test_integrator
          "${MESHES}/cube/cube.dmg"


### PR DESCRIPTION
move the implementation of NoSharing to be with the other sharing types

change it to be a singleton (which I usually hate but is actually warranted because NoSharing is basically just a stateless functor and we only ever need to retrieve a pointer to it externally) 

modify countEntitiesOfType to allow counting based on Sharings without changing the API semantics

add two tests to the test suite to test both a serial and partitioned mesh