### PR TITLE
make ENABLE_ZOLTAN available to preprocessor

### DIFF
--- a/zoltan/CMakeLists.txt
+++ b/zoltan/CMakeLists.txt
@@ -38,8 +38,14 @@ else()
   )
 endif()
 
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/apfZoltanConfig.h.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/apfZoltanConfig.h")
+
+# Set include directory for building apf_zoltan target
+include_directories("${CMAKE_CURRENT_BINARY_DIR}")
+
 # Package headers
-set(HEADERS apfZoltan.h)
+set(HEADERS apfZoltan.h "${CMAKE_CURRENT_BINARY_DIR}/apfZoltanConfig.h")
 
 # Add the apf_zoltan library
 add_library(apf_zoltan ${SOURCES})
@@ -49,6 +55,12 @@ target_include_directories(apf_zoltan INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<INSTALL_INTERFACE:include>
     )
+
+# Set include directory for generated header for targets linking to apf_zoltan
+target_include_directories(apf_zoltan INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    )
+
 
 # Link this package to these libraries
 target_link_libraries(apf_zoltan PUBLIC pcu apf)

--- a/zoltan/apfZoltan.h
+++ b/zoltan/apfZoltan.h
@@ -29,6 +29,7 @@
   \brief Zoltan partitioning for apf::Mesh objects */
 
 #include <apfNumbering.h>
+#include <apfZoltanConfig.h>
 
 namespace apf {
 

--- a/zoltan/apfZoltanConfig.h.in
+++ b/zoltan/apfZoltanConfig.h.in
@@ -1,0 +1,1 @@
+#cmakedefine ENABLE_ZOLTAN


### PR DESCRIPTION
This makes the `ENABLE_ZOLTAN` flag passed to CMake available to the C pre-processor (via a CMake generated header).  The motivation for this is trying to make code work with or without Zoltan, ie:

```
#ifdef ENABLE_ZOLTAN
  apf::Splitter* splitter = apf::makeZoltanSplitter(...);
#else 
  apf::Splitter* splitter = Parma_MakeRibSplitter(...);
#fi
# do stuff with splitter
```