### PR TITLE
Prevent copy constructor being called silently.

### DIFF
--- a/mth/mth.h
+++ b/mth/mth.h
@@ -22,11 +22,11 @@ namespace mth {
 
 /** \brief returns vector cross product */
 template <class T>
-Vector<T,3> cross(Vector<T,3> const& a, Vector<T,3> const& b);
+Vector3<T> cross(Vector<T,3> const& a, Vector<T,3> const& b);
 
 /** \brief returns the cross product matrix for the vector */
 template <class T>
-Matrix<T,3,3> cross(Vector<T,3> const& a);
+Matrix3x3<T> cross(Vector<T,3> const& a);
 
 /** \brief returns vector a projected onto vector b */
 template <class T, unsigned N>

--- a/mth/mth_def.h
+++ b/mth/mth_def.h
@@ -22,7 +22,7 @@ T norm(Vector<T,M> const& a)
 }
 
 template <class T>
-Vector<T,3> cross(Vector<T,3> const& a, Vector<T,3> const& b)
+Vector3<T> cross(Vector<T,3> const& a, Vector<T,3> const& b)
 {
   Vector3<T> r;
   r(0) = a(1)*b(2) - a(2)*b(1);
@@ -32,7 +32,7 @@ Vector<T,3> cross(Vector<T,3> const& a, Vector<T,3> const& b)
 }
 
 template <class T>
-Matrix<T,3,3> cross(Vector<T,3> const& a)
+Matrix3x3<T> cross(Vector<T,3> const& a)
 {
   Matrix3x3<T> r(
       0, -a(2),  a(1),


### PR DESCRIPTION
Copy constructor is being called under LLVM 7 and 8 on osx because base types are being returned instead of instantiated derived types.  Error triggered by -Wreturn-std-move.