### PR TITLE
Partial solution for issue #272

### DIFF
--- a/apf/apf.cc
+++ b/apf/apf.cc
@@ -19,6 +19,7 @@
 #include "apfUserData.h"
 #include "apfVtk.h"
 #include "apfNumberingClass.h"
+#include "apfNumbering.h"
 #include <cstdio>
 #include <cstdlib>
 #include <pcu_util.h>
@@ -28,6 +29,11 @@ namespace apf {
 
 void destroyMesh(Mesh* m)
 {
+  // numberings must be destroyed before fields!
+  while(m->countNumberings())
+    destroyNumbering(m->getNumbering(0));
+  while(m->countGlobalNumberings())
+    destroyGlobalNumbering(m->getGlobalNumbering(0));
   while (m->countFields())
     destroyField(m->getField(0));
   delete m;

--- a/apf/apfMesh.cc
+++ b/apf/apfMesh.cc
@@ -313,6 +313,7 @@ int Mesh::countFields()
 
 Field* Mesh::getField(int i)
 {
+  PCU_DEBUG_ASSERT(i < static_cast<int>(fields.size()) && i >= 0);
   return fields[i];
 }
 
@@ -323,7 +324,9 @@ void Mesh::addNumbering(Numbering* n)
 
 void Mesh::removeNumbering(Numbering* n)
 {
-  numberings.erase(std::find(numberings.begin(),numberings.end(),n));
+  std::vector<Numbering*>::iterator it = std::find(numberings.begin(),numberings.end(),n);
+  if (it != numberings.end())
+    numberings.erase(it);
 }
 
 Numbering* Mesh::findNumbering(const char* name)
@@ -351,6 +354,7 @@ int Mesh::countNumberings()
 
 Numbering* Mesh::getNumbering(int i)
 {
+  PCU_DEBUG_ASSERT(i < static_cast<int>(numberings.size()) && i >= 0);
   return numberings[i];
 }
 
@@ -361,8 +365,10 @@ void Mesh::addGlobalNumbering(GlobalNumbering* n)
 
 void Mesh::removeGlobalNumbering(GlobalNumbering* n)
 {
-  globalNumberings.erase(std::find(
-        globalNumberings.begin(), globalNumberings.end(), n));
+  std::vector<GlobalNumbering*>::iterator it = std::find(globalNumberings.begin(),
+                                                         globalNumberings.end(), n);
+  if(it != globalNumberings.end())
+    globalNumberings.erase(it);
 }
 
 int Mesh::countGlobalNumberings()
@@ -372,6 +378,7 @@ int Mesh::countGlobalNumberings()
 
 GlobalNumbering* Mesh::getGlobalNumbering(int i)
 {
+  PCU_DEBUG_ASSERT(i < static_cast<int>(globalNumberings.size()) && i >= 0);
   return globalNumberings[i];
 }
 

--- a/apf/apfNumbering.cc
+++ b/apf/apfNumbering.cc
@@ -46,10 +46,12 @@ void NumberingOf<T>::init(
 }
 
 template <class T>
-void NumberingOf<T>::init(Field* f)
+void NumberingOf<T>::init(Field* f, bool global)
 {
   field = f;
   std::string nm = f->getName();
+  if(global)
+    nm += "_global";
   nm += "_num";
   init(nm.c_str(),
       f->getMesh(),
@@ -123,8 +125,11 @@ Numbering* createNumbering(
 
 void destroyNumbering(Numbering* n)
 {
-  n->getMesh()->removeNumbering(n);
-  delete n;
+  if(n)
+  {
+    n->getMesh()->removeNumbering(n);
+    delete n;
+  }
 }
 
 void fix(Numbering* n, MeshEntity* e, int node, int component, bool fixed)
@@ -470,7 +475,7 @@ GlobalNumbering* createGlobalNumbering(
 GlobalNumbering* createGlobalNumbering(Field* f)
 {
   GlobalNumbering* n = new GlobalNumbering();
-  n->init(f);
+  n->init(f, true);
   f->getMesh()->addGlobalNumbering(n);
   return n;
 }
@@ -612,8 +617,11 @@ void synchronize(GlobalNumbering* n, Sharing* shr)
 
 void destroyGlobalNumbering(GlobalNumbering* n)
 {
-  n->getMesh()->removeGlobalNumbering(n);
-  delete n;
+  if(n)
+  {
+    n->getMesh()->removeGlobalNumbering(n);
+    delete n;
+  }
 }
 
 void getNodes(GlobalNumbering* n, DynamicArray<Node>& nodes)

--- a/apf/apfNumberingClass.h
+++ b/apf/apfNumberingClass.h
@@ -23,7 +23,7 @@ class NumberingOf : public FieldBase
               Mesh* m,
               FieldShape* s,
               int c);
-    void init(Field* f);
+    void init(Field* f, bool global=false);
     Field* getField();
     FieldDataOf<T>* getData();
     void getAll(MeshEntity* e, T* dat);

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -595,6 +595,8 @@ class MeshMDS : public Mesh2
         apf::destroyField(this->getField(0));
       while (this->countNumberings())
         apf::destroyNumbering(this->getNumbering(0));
+      while (this->countGlobalNumberings())
+        apf::destroyGlobalNumbering(this->getGlobalNumbering(0));
       apf::destroyField(coordinateField);
       coordinateField = 0;
       gmi_model* model = static_cast<gmi_model*>(mesh->user_model);

--- a/test/verify_convert.cc
+++ b/test/verify_convert.cc
@@ -61,8 +61,9 @@ int main(int argc, char* argv[])
   apf::Numbering* numNoField = apf::createNumbering(
       m1, "noField", apf::getShape(f), apf::countComponents(f));
   apf::GlobalNumbering* globalNumWithField = apf::createGlobalNumbering(f);
+
   apf::GlobalNumbering* globalNumNoField = apf::createGlobalNumbering(
-      m1, "noField", apf::getShape(f), apf::countComponents(f));
+      m1, "noField_global", apf::getShape(f), apf::countComponents(f));
   // create an integer tag
   apf::MeshTag* intTag = m1->createIntTag("intTag", 1);
   // loop over all vertices in mesh and set values
@@ -108,7 +109,8 @@ int main(int argc, char* argv[])
   assert(getField(m2->findNumbering(apf::getName(numWithField))) == f2);
   assert(getField(m2->findGlobalNumbering(apf::getName(globalNumWithField))) == f2);
   // update the user field to reference the field in mesh 2
-  apf::updateUserField(uf2, new twox(f2));
+  apf::Function* func2 = new twox(f2);
+  apf::updateUserField(uf2, func2);
   // find the copied tag data
   apf::MeshTag* intTag2 = m2->findTag("intTag");
   assert(intTag2);
@@ -151,6 +153,7 @@ int main(int argc, char* argv[])
 
   // cleanup
   delete func;
+  delete func2;
   m1->destroyNative();
   m2->destroyNative();
   m3->destroyNative();


### PR DESCRIPTION
This commit shows at a high level how the memory leak should be expected
to be fixed. It however causes a segfault for some test cases
(verify_convert, and mixedNumbering).

The segfault seems to come from mds trying to delete the same tags
multiple times.