### PR TITLE
Add support for reading 2D ugrid files

### DIFF
--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -196,6 +196,9 @@ Mesh2* loadMdsFromGmsh(gmi_model* g, const char* filename);
 
 Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename);
 
+Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename,
+                        const int mesh_dim);
+
 void printUgridPtnStats(gmi_model* g, const char* ugridfile, const char* ptnfile,
     const double elmWeights[]);
 

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -196,9 +196,6 @@ Mesh2* loadMdsFromGmsh(gmi_model* g, const char* filename);
 
 Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename);
 
-Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename,
-                        const int mesh_dim);
-
 void printUgridPtnStats(gmi_model* g, const char* ugridfile, const char* ptnfile,
     const double elmWeights[]);
 

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -50,7 +50,7 @@ namespace {
     unsigned nvtx, ntri, nquad, ntet, npyr, nprz, nhex, nbdry;
     void print() {
       lion_eprint(1,
-          "nvtx %u ntri %u nquad %u ntet %u npyr %u nprz %u nhex %u\n",        
+          "nvtx %u ntri %u nquad %u ntet %u npyr %u nprz %u nhex %u\n",
           nvtx,ntri,nquad,ntet,npyr,nprz,nhex);
     }
   };
@@ -114,7 +114,6 @@ namespace {
     readUnsigneds(r->file, &nbdry_elem, 1, r->swapBytes);
     PCU_ALWAYS_ASSERT(nbdry_elem < biggest);
     h->nbdry = nbdry_elem;
-    std::cout << nbdry_elem << " boundary elements\n";
   }
 
   apf::MeshEntity* makeVtx(Reader* r,
@@ -273,7 +272,6 @@ namespace {
   void classifyBoundaryElms(Reader* r, unsigned nbdry, int apfType)
   {
     const unsigned nverts = apf::Mesh::adjacentCount[apfType][0];
-    std::cout << "nverts: " << nverts << "\n";
     unsigned* vtx = r->edgeVerts;
     unsigned* tags = r->edgeTags;
     for(unsigned id=0; id<nbdry; id++) {
@@ -305,7 +303,6 @@ namespace {
 
   void classifyVtx(Reader *r, header* h) {
     (void)h;
-    // const unsigned nvtx = h->nvtx;
     apf::Mesh2* m = r->mesh;
     apf::MeshIterator* it = m->begin(0);
     apf::MeshEntity* vtx;
@@ -321,14 +318,9 @@ namespace {
         upward_dim[id] = m->getModelType(gent);
         upward_id[id] = m->getModelTag(gent);
       }
-      // std::cout << "model classification dim on upward adjactent edges: ";
-      // for (int i = 0; i < num_up; i++)
-      // {
-      //   std::cout << upward_dim[i] << ", ";
-      // }
+
       apf::Vector3 vtx_coord;
       m->getPoint(vtx, 0, vtx_coord);
-      // std::cout << "on vertex at point: (" << vtx_coord[0] << ", " << vtx_coord[1] << ", " << vtx_coord[2] << ")\n";
       bool same_dim = std::all_of(upward_dim.begin(), upward_dim.end(), 
                                   [upward_dim](const int i) {
                                     return upward_dim[0] == i;
@@ -503,17 +495,17 @@ namespace {
       PCU_ALWAYS_ASSERT(elm);
 
       r->mesh->setModelEntity(elm, g);
-      // /// tag all downward adjacent entities with the element's model ent
-      // const unsigned nadj = apf::Mesh::adjacentCount[apfType][0];
-      // apf::Downward down;
-      // for (int dim = 1; dim >= 0; dim--)
-      // {
-      //   r->mesh->getDownward(elm, dim, down);
-      //   for (unsigned i = 0; i < nadj; i++)
-      //   {
-      //     r->mesh->setModelEntity(down[i], g);
-      //   }
-      // }
+      /// tag all downward adjacent entities with the element's model ent
+      const unsigned nadj = apf::Mesh::adjacentCount[apfType][0];
+      apf::Downward down;
+      for (int dim = 1; dim >= 0; dim--)
+      {
+        r->mesh->getDownward(elm, dim, down);
+        for (unsigned i = 0; i < nadj; i++)
+        {
+          r->mesh->setModelEntity(down[i], g);
+        }
+      }
     }
     free(vtx);
     free(elm_model_id);
@@ -555,22 +547,15 @@ namespace {
     hdr.print();
     readNodes(&r, &hdr);
     setNodeIds(&r, &hdr);
-    std::cout << "set faces and tags\n";
     read2DElms(&r,&hdr);
-    std::cout << "read elems\n";
     checkFilePos(&r,&hdr);
-    std::cout << "check file pos\n";
     readNumBdryElms(&r, &hdr);
     readBdryElmsAndTags(&r, &hdr);
     setBoundaryTags(&r,&hdr);
     classifyBoundaryElms(&r, &hdr);
     classifyVtx(&r, &hdr);
-    std::cout << "set face tags\n";
     freeReader(&r);
-    std::cout << "free reader\n";
     m->acceptChanges();
-    std::cout << "accepted changes\n";
-
   }
 
   void getMaxAndAvg(std::set<int>*& cnt, int numparts, int& max, double& avg) {
@@ -719,39 +704,6 @@ namespace {
 }
 
 namespace apf {
-  // Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename)
-  // {
-  //   Mesh2* m = makeEmptyMdsMesh(g, 0, false);
-  //   apf::changeMdsDimension(m, 3);
-  //   readUgrid(m, filename);
-  //   lion_eprint(1,"vtx %lu edge %lu face %lu rgn %lu\n",
-  //       m->count(0), m->count(1), m->count(2), m->count(3));
-  //   return m;
-  // }
-
-  // Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename,
-  //                         const int mesh_dim)
-  // {
-  //   PCU_ALWAYS_ASSERT(mesh_dim >= 2);
-  //   if (3 == mesh_dim)
-  //     return loadMdsFromUgrid(g, filename);
-  //   else if (2 == mesh_dim)
-  //   {
-  //     Mesh2* m = makeEmptyMdsMesh(g, 0, false);
-  //     apf::changeMdsDimension(m, mesh_dim);
-  //     readUgrid2D(m, filename);
-  //     std::cout << "read ugrid\n";
-  //     lion_eprint(1,"vtx %lu edge %lu face %lu rgn %lu\n",
-  //                 m->count(0), m->count(1), m->count(2), m->count(3));
-  //     return m;
-  //   }
-  //   else // silence compiler warning
-  //   {
-  //     Mesh2* m = makeEmptyMdsMesh(g, 0, false);
-  //     return m;
-  //   }
-  // }
-
   Mesh2* loadMdsFromUgrid(gmi_model* g, const char* filename)
   {
     Mesh2* m = makeEmptyMdsMesh(g, 0, false);
@@ -770,7 +722,7 @@ namespace apf {
     else if (3 == dim)
       read3DUgrid(m, filename);
     lion_eprint(1,"vtx %lu edge %lu face %lu rgn %lu\n",
-                  m->count(0), m->count(1), m->count(2), m->count(3));
+        m->count(0), m->count(1), m->count(2), m->count(3));
     return m;
   }
 

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -495,17 +495,6 @@ namespace {
       PCU_ALWAYS_ASSERT(elm);
 
       r->mesh->setModelEntity(elm, g);
-      /// tag all downward adjacent entities with the element's model ent
-      const unsigned nadj = apf::Mesh::adjacentCount[apfType][0];
-      apf::Downward down;
-      for (int dim = 1; dim >= 0; dim--)
-      {
-        r->mesh->getDownward(elm, dim, down);
-        for (unsigned i = 0; i < nadj; i++)
-        {
-          r->mesh->setModelEntity(down[i], g);
-        }
-      }
     }
     free(vtx);
     free(elm_model_id);

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -11,7 +11,7 @@
 #include <cstdlib>
 
 #include <gmi.h>
-
+#include <algorithm>
 #include <iostream>
 
 /*

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -321,14 +321,14 @@ namespace {
         upward_dim[id] = m->getModelType(gent);
         upward_id[id] = m->getModelTag(gent);
       }
-      std::cout << "model classification dim on upward adjactent edges: ";
-      for (int i = 0; i < num_up; i++)
-      {
-        std::cout << upward_dim[i] << ", ";
-      }
+      // std::cout << "model classification dim on upward adjactent edges: ";
+      // for (int i = 0; i < num_up; i++)
+      // {
+      //   std::cout << upward_dim[i] << ", ";
+      // }
       apf::Vector3 vtx_coord;
       m->getPoint(vtx, 0, vtx_coord);
-      std::cout << "on vertex at point: (" << vtx_coord[0] << ", " << vtx_coord[1] << ", " << vtx_coord[2] << ")\n";
+      // std::cout << "on vertex at point: (" << vtx_coord[0] << ", " << vtx_coord[1] << ", " << vtx_coord[2] << ")\n";
       bool same_dim = std::all_of(upward_dim.begin(), upward_dim.end(), 
                                   [upward_dim](const int i) {
                                     return upward_dim[0] == i;
@@ -345,6 +345,15 @@ namespace {
         ///   then classify the vertex on that same geometric entity
         apf::ModelEntity* gent = m->findModelEntity(upward_dim[0], upward_id[0]);
         m->setModelEntity(vtx, gent);
+
+        if (gmi_can_get_closest_point(m->getModel()))
+        {
+          apf::Vector3 from, to, param;
+          m->getPoint(vtx, 0, from);
+          m->getClosestPoint(gent, from, to, param);
+          std::cout << "param from: " << from << " and param to: " << to << "\n";
+          m->setParam(vtx, param);
+        }
       }
       else
       {
@@ -376,6 +385,16 @@ namespace {
           /// (for a vertex on the boundary)
           apf::ModelEntity* gent = m->findModelEntity(1, edge_id[0]);
           m->setModelEntity(vtx, gent);
+
+          /// specify parametric coordinate of vertex on edge
+          if (gmi_can_get_closest_point(m->getModel()))
+          {
+            apf::Vector3 from, to, param;
+            m->getPoint(vtx, 0, from);
+            m->getClosestPoint(gent, from, to, param);
+            std::cout << "param from: " << from << " and param to: " << to << "\n";
+            m->setParam(vtx, param);
+          }
         }
         else /// a mesh vertex whose adjacent edges are classified on different
              ///   model edges must be classified on a model vertex

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -324,7 +324,7 @@ namespace {
       PCU_ALWAYS_ASSERT(elm);
     }
     unsigned* dummy_id = (unsigned*) calloc(nelms,sizeof(unsigned));
-    readUnsigneds(r->file, dummy_id, cnt, r->swapBytes);
+    readUnsigneds(r->file, dummy_id, nelms, r->swapBytes);
 
     free(vtx);
     free(dummy_id);

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -258,8 +258,6 @@ namespace {
       int val = tags[id];
       r->mesh->setIntTag(f, t, &val);
     }
-    // free(vtx);
-    // free(tags);
     lion_eprint(1, "set %d %s face tags\n",
         nbdry, apf::Mesh::typeName[apfType]);
   }
@@ -276,15 +274,11 @@ namespace {
     unsigned* tags = r->edgeTags;
     for(unsigned id=0; id<nbdry; id++) {
       apf::Downward verts;
-      std::cout << "boundary edge " << id << " has verts: ";
       for(unsigned j=0; j<nverts; j++) {
-        std::cout << vtx[id*nverts+j] << ", ";
         verts[j] = lookupVert(r, vtx[id*nverts+j]);
         apf::Vector3 vtx_coord;
         r->mesh->getPoint(verts[j], 0, vtx_coord);
-        std::cout << "at point: (" << vtx_coord[0] << ", " << vtx_coord[1] << ", " << vtx_coord[2] << "), ";
       }
-      std::cout << std::endl;
       apf::MeshEntity* f =
         apf::findElement(r->mesh, apfType, verts);
       PCU_ALWAYS_ASSERT(f);
@@ -325,12 +319,10 @@ namespace {
                                   [upward_dim](const int i) {
                                     return upward_dim[0] == i;
                                   });
-      std::cout << "same dim? " << same_dim << "\n";
       bool same_id = std::all_of(upward_id.begin(), upward_id.end(), 
                                  [upward_id](const int i) {
                                    return upward_id[0] == i;
                                  });
-      std::cout << "same id? " << same_id << "\n";
       if (same_dim && same_id)
       {
         /// if all edges adjacent to a vertex have the same classification
@@ -343,7 +335,6 @@ namespace {
           apf::Vector3 from, to, param;
           m->getPoint(vtx, 0, from);
           m->getClosestPoint(gent, from, to, param);
-          std::cout << "param from: " << from << " and param to: " << to << "\n";
           m->setParam(vtx, param);
         }
       }
@@ -368,7 +359,6 @@ namespace {
                                         [edge_id](const int i) {
                                           return edge_id[0] == i;
                                         });
-        std::cout << "same edge id?: " << same_edge_id << "\n";
         if (same_edge_id)
         {
           /// if the edges adjacent to a vertex that are classified on a dim 1
@@ -384,7 +374,6 @@ namespace {
             apf::Vector3 from, to, param;
             m->getPoint(vtx, 0, from);
             m->getClosestPoint(gent, from, to, param);
-            std::cout << "param from: " << from << " and param to: " << to << "\n";
             m->setParam(vtx, param);
           }
         }
@@ -393,30 +382,20 @@ namespace {
         {
           apf::Vector3 vtx_coord;
           m->getPoint(vtx, 0, vtx_coord);
-          std::cout << "got vertex point\n";
 
           /// it doesn't matter which edge
           apf::ModelEntity* gent = m->findModelEntity(1, edge_id[0]);
           gmi_set* adjacent_verts = gmi_adjacent(m->getModel(), (gmi_ent*)gent, 0);
           int n_adj_verts = adjacent_verts->n;
-          std::cout << "got " << n_adj_verts << " adjacent verts\n";
           double p[2];
           double x[3];
           for (int j = 0; j < n_adj_verts; j++)
           {
-            if (adjacent_verts->e[j] == NULL)
-            {
-              std::cout << "null ptr\n";
-            }
             gmi_eval(m->getModel(), adjacent_verts->e[j], p, x);
-            std::cout << "eval'd vert " << j << "\n";
             apf::Vector3 vec_x(x);
-            std::cout << "mesh vtx coord:(" << vtx_coord[0] << ", " << vtx_coord[1] << ", " << vtx_coord[2] << ")\n";
-            std::cout << "model vtx coord:(" << vec_x[0] << ", " << vec_x[1] << ", " << vec_x[2] << ")\n";
 
             /// only look at x and y dimensions of vector, model must be in x-y plane, but need not be at z=0
             double mag = pow(pow((vtx_coord[0] - vec_x[0]), 2) + pow((vtx_coord[1] - vec_x[1]), 2), 0.5);
-            std::cout << "with mag: " << mag << "\n";
             if (mag < 0.001)
             {
               m->setModelEntity(vtx, (apf::ModelEntity*)adjacent_verts->e[j]);
@@ -485,13 +464,7 @@ namespace {
         verts[mdsIdx] = lookupVert(r, vtx[i*nverts+j]);
       }
       apf::ModelEntity* g = r->mesh->findModelEntity(2, elm_model_id[i]);
-      // apf::ModelEntity* g = r->mesh->findModelEntity(2, 0);
-      if (!g) {
-        std::cout << "null ent\n";
-      }
-      std::cout << "elm tag: " << elm_model_id[i] << "\n";
-      apf::MeshEntity* elm =
-        apf::buildElement(r->mesh, g, apfType, verts);
+      apf::MeshEntity* elm = apf::buildElement(r->mesh, g, apfType, verts);
       PCU_ALWAYS_ASSERT(elm);
 
       r->mesh->setModelEntity(elm, g);

--- a/mds/mdsUgrid.cc
+++ b/mds/mdsUgrid.cc
@@ -323,7 +323,11 @@ namespace {
         apf::buildElement(r->mesh, g, apfType, verts);
       PCU_ALWAYS_ASSERT(elm);
     }
+    unsigned* dummy_id = (unsigned*) calloc(nelms,sizeof(unsigned));
+    readUnsigneds(r->file, dummy_id, cnt, r->swapBytes);
+
     free(vtx);
+    free(dummy_id);
     lion_eprint(1, "read %d %s\n", nelms, apf::Mesh::typeName[apfType]);
   }
 


### PR DESCRIPTION
This PR addresses #281 and extends `apf::loadMdsFromUgrid` to support reading 2D ugrid meshes. It sets the parametric values of mesh vertices for 2D meshes by inverse evaluating the geometric model at the coordinates of the vertex, if the `gmi` model supports the inverse evaluation.

**NOTE**: I've used C++11 features in the code that sets vertex parametric coordinates (the developer guide doesn't specify what maximum standard should be used).