### PR TITLE
Add region classification to apf::deriveMdlFromManifold

### DIFF
--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -1156,6 +1156,7 @@ void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 
 void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 			     int nBEdges, int (*bEdges)[4],
+                 std::vector<int> regionIDs,
 			     GlobalToVert &globalToVert,
 			     std::map<int, apf::MeshEntity*> &globalToFace)
 {
@@ -1216,6 +1217,13 @@ void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
         mesh->setIntTag(vertsAdjToEdge[k], classifnTag, newTagData);
       }
     }
+  }
+
+  for (std::vector<int>::iterator it = regionIDs.begin() ; it != regionIDs.end(); ++it)
+  {
+    tagData[0] = 2;
+    tagData[1] = regionIDs[*it];
+    mesh->setIntTag(globalToFace[*it],classifnTag,tagData);
   }
 
   // TODO: Use classifnTag to classify

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -1230,9 +1230,45 @@ void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 
   for(unsigned int i=0; i<regionIDs.size();i++)
   {
-    tagData[0] = 2;
-    tagData[1] = regionIDs[i];
+    tagData[0] = newTagData[0] = 2;
+    tagData[1] = newTagData[1] = regionIDs[i];
+
     mesh->setIntTag(globalToFace[i],classifnTag,tagData);
+
+    //check edge adjacency and classify if not classified already
+    mesh->getDownward(globalToFace[i], 1, edgesAdjToFace);
+    for (int k = 0; k <2; ++k) {
+        if (mesh->hasTag(edgesAdjToFace[k], classifnTag)) 
+        {
+            mesh->getIntTag(edgesAdjToFace[k], classifnTag, tagData);
+            if (tagData[0] > newTagData[0]) 
+            {
+	             mesh->setIntTag(edgesAdjToFace[k], classifnTag, newTagData);
+            }
+        } 
+        else 
+        {
+            // Edge has no classification, use the region's
+            mesh->setIntTag(edgesAdjToFace[k], classifnTag, newTagData);
+        }
+        
+
+        //get vertices in the meantime
+        mesh->getDownward(edgesAdjToFace[k], 0, vertsAdjToEdge);
+        for (int k = 0; k <2; ++k) {
+            if (mesh->hasTag(vertsAdjToEdge[k], classifnTag)) {
+	            mesh->getIntTag(vertsAdjToEdge[k], classifnTag, tagData);
+                if (tagData[0] > newTagData[0]) {
+	                mesh->setIntTag(vertsAdjToEdge[k], classifnTag, newTagData);
+                }
+            } else {
+                // Vertex has no classification, use the edge's
+                mesh->setIntTag(vertsAdjToEdge[k], classifnTag, newTagData);
+            }
+        }
+
+    }
+
   }
 
   // TODO: Use classifnTag to classify

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -1237,7 +1237,7 @@ void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 
     //check edge adjacency and classify if not classified already
     mesh->getDownward(globalToFace[i], 1, edgesAdjToFace);
-    for (int k = 0; k <2; ++k) {
+    for (int k = 0; k < 3; ++k) {
         if (mesh->hasTag(edgesAdjToFace[k], classifnTag)) 
         {
             mesh->getIntTag(edgesAdjToFace[k], classifnTag, tagData);
@@ -1255,7 +1255,7 @@ void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 
         //get vertices in the meantime
         mesh->getDownward(edgesAdjToFace[k], 0, vertsAdjToEdge);
-        for (int k = 0; k <2; ++k) {
+        for (int k = 0; k < 2; ++k) {
             if (mesh->hasTag(vertsAdjToEdge[k], classifnTag)) {
 	            mesh->getIntTag(vertsAdjToEdge[k], classifnTag, tagData);
                 if (tagData[0] > newTagData[0]) {

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -1219,11 +1219,11 @@ void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
     }
   }
 
-  for (std::vector<int>::iterator it = regionIDs.begin() ; it != regionIDs.end(); ++it)
+  for(unsigned int i=0; i<regionIDs.size();i++)
   {
     tagData[0] = 2;
-    tagData[1] = regionIDs[*it];
-    mesh->setIntTag(globalToFace[*it],classifnTag,tagData);
+    tagData[1] = regionIDs[i];
+    mesh->setIntTag(globalToFace[i],classifnTag,tagData);
   }
 
   // TODO: Use classifnTag to classify

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -1040,6 +1040,7 @@ void deriveMdsModel(Mesh2* in)
 
 void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
                            int nBFaces, int (*bFaces)[5],
+                           std::vector<int> regionIDs,
                            GlobalToVert &globalToVert,
                            std::map<int, apf::MeshEntity*> &globalToRegion)
 {
@@ -1129,6 +1130,14 @@ void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
       }
     }
   }
+
+  for(unsigned int i=0; i<regionIDs.size();i++)
+  {
+    tagData[0] = 3;
+    tagData[1] = regionIDs[i];
+    mesh->setIntTag(globalToRegion[i],classifnTag,tagData);
+  }
+
 
   MeshMDS* m = static_cast<MeshMDS*>(mesh);
   if ((classifnTag)) {

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -167,7 +167,7 @@ void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
  *  \param globalToFace Maps mesh face ID to the mesh face
  */
 void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
-			     int nBEdges, int (*bEdges)[4],
+			     int nBEdges, int (*bEdges)[4], int* regionIDs,
 			     GlobalToVert &globalToVert,
 			     std::map<int, apf::MeshEntity*> &globalToFace);
 

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -138,12 +138,14 @@ void deriveMdsModel(Mesh2* in);
  *  \param bFaces 2D Array of size (n_bfaces x 5). For each face, the row is
  *         [model_face_tag, adj_region_tag, global_vtx_id_1,
  *         global_vtx_id_2, global_vtx_id_3]
+ *  \param regionIDs is a vector of the region classification for each mesh region
  *  \param globalToVert Maps mesh vertex ID to the mesh vertex. Typically
  *         output from apf::construct
  *  \param globalToRegion Maps mesh region ID to the mesh region
  */
 void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
 			   int nBFaces, int (*bFaces)[5],
+               std::vector<int> regionIDs,
 			   GlobalToVert &globalToVert,
 			   std::map<int, apf::MeshEntity*> &globalToRegion);
 
@@ -163,6 +165,7 @@ void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
  *  \param nBEdges number of boundary faces
  *  \param bEdges 2D Array of size (nBEdges x 4). For each face, the row is
  *         [model_edge_tag, adj_face_tag, global_vtx_id_1, global_vtx_id_2]
+ *  \param regionIDs is a vector of the region classification for each mesh region
  *  \param globalToVert Maps mesh vertex ID to the mesh vertex. Typically
  *         output from apf::construct
  *  \param globalToFace Maps mesh face ID to the mesh face

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -31,6 +31,7 @@
   \brief Interface to the compact Mesh Data Structure */
 
 #include <map>
+#include <vector>
 
 struct gmi_model;
 

--- a/mds/apfMDS.h
+++ b/mds/apfMDS.h
@@ -167,7 +167,7 @@ void deriveMdlFromManifold(Mesh2* mesh, bool* isModelVert,
  *  \param globalToFace Maps mesh face ID to the mesh face
  */
 void derive2DMdlFromManifold(Mesh2* mesh, bool* isModelVert,
-			     int nBEdges, int (*bEdges)[4], int* regionIDs,
+			     int nBEdges, int (*bEdges)[4], std::vector<int> regionIDs,
 			     GlobalToVert &globalToVert,
 			     std::map<int, apf::MeshEntity*> &globalToFace);
 


### PR DESCRIPTION
PR to add mesh region to model region classification to the 2D/3D functions for deriving a discrete geometry based on mesh entity classifications. 

This is needed for the Proteus project to work correctly with multi-region domains.

Based on how the model is derived, there isn't a clear way to define the bounding surfaces for the model regions or how the regions are separated. I do not know how this will affect mesh adaptation.
