### PR TITLE
Higher order size field

### DIFF
--- a/ma/CMakeLists.txt
+++ b/ma/CMakeLists.txt
@@ -25,6 +25,7 @@ set(SOURCES
   maLayerCollapse.cc
   maMatch.cc
   maSolutionTransfer.cc
+  maSolutionTransferHelper.cc
   maSnap.cc
   maEdgeSwap.cc
   maShape.cc

--- a/ma/maAdapt.cc
+++ b/ma/maAdapt.cc
@@ -353,12 +353,14 @@ Cavity::Cavity()
   adapter = 0;
   solutionTransfer = 0;
   shape = 0;
+  shouldTransferSizeField = false;
 }
 
 void Cavity::init(Adapt* a)
 {
   adapter = a;
   solutionTransfer = a->solutionTransfer;
+  sizeField = a->sizeField;
   shape = a->shape;
   Mesh* m = a->mesh;
   shouldTransfer = false;
@@ -368,6 +370,8 @@ void Cavity::init(Adapt* a)
       shouldTransfer = true;
     if (shape->hasNodesOn(d))
       shouldFit = true;
+    if (sizeField->getTransferDimension())
+      shouldTransferSizeField = true;
   }
 }
 
@@ -408,6 +412,12 @@ void Cavity::transfer(EntityArray& oldElements)
     EntityArray a;
     newEntities.retrieve(a);
     solutionTransfer->onCavity(oldElements,a);
+  }
+  if (shouldTransferSizeField)
+  {
+    EntityArray a;
+    newEntities.retrieve(a);
+    sizeField->onCavity(oldElements,a);
   }
 }
 

--- a/ma/maAdapt.cc
+++ b/ma/maAdapt.cc
@@ -360,7 +360,6 @@ void Cavity::init(Adapt* a)
 {
   adapter = a;
   solutionTransfer = a->solutionTransfer;
-  sizeField = a->sizeField;
   shape = a->shape;
   Mesh* m = a->mesh;
   shouldTransfer = false;
@@ -370,7 +369,7 @@ void Cavity::init(Adapt* a)
       shouldTransfer = true;
     if (shape->hasNodesOn(d))
       shouldFit = true;
-    if (sizeField->getTransferDimension())
+    if (adapter->sizeField->hasNodesOn(d))
       shouldTransferSizeField = true;
   }
 }
@@ -417,7 +416,7 @@ void Cavity::transfer(EntityArray& oldElements)
   {
     EntityArray a;
     newEntities.retrieve(a);
-    sizeField->onCavity(oldElements,a);
+    adapter->sizeField->onCavity(oldElements,a);
   }
 }
 

--- a/ma/maAdapt.h
+++ b/ma/maAdapt.h
@@ -137,11 +137,13 @@ class Cavity
     void fit(EntityArray& oldElements);
     bool shouldTransfer;
     bool shouldFit;
+    bool shouldTransferSizeField;
   private:
     Adapt* adapter;
     SolutionTransfer* solutionTransfer;
     ShapeHandler* shape;
     NewEntities newEntities;
+    SizeField* sizeField;
 };
 
 Entity* buildVertex(

--- a/ma/maAdapt.h
+++ b/ma/maAdapt.h
@@ -143,7 +143,6 @@ class Cavity
     SolutionTransfer* solutionTransfer;
     ShapeHandler* shape;
     NewEntities newEntities;
-    SizeField* sizeField;
 };
 
 Entity* buildVertex(

--- a/ma/maFaceSplit.cc
+++ b/ma/maFaceSplit.cc
@@ -123,16 +123,22 @@ void FaceSplit::cancel()
 void FaceSplit::transfer()
 {
   Mesh* m = adapter->mesh;
-  SolutionTransfer* st = adapter->solutionTransfer;
-  int td = st->getTransferDimension();
-  for (int d = td; d <= m->getDimension(); ++d)
-    for (size_t i = 0; i < toSplit[d].getSize(); ++i)
-      st->onRefine(toSplit[d][i], newEntities[d][i]);
-
+  int td;
   td = adapter->shape->getTransferDimension();
   for (int d = td; d <= m->getDimension(); ++d)
     for (size_t i = 0; i < toSplit[d].getSize(); ++i)
       adapter->shape->onRefine(toSplit[d][i], newEntities[d][i]);
+
+  SolutionTransfer* st = adapter->solutionTransfer;
+  td = st->getTransferDimension();
+  for (int d = td; d <= m->getDimension(); ++d)
+    for (size_t i = 0; i < toSplit[d].getSize(); ++i)
+      st->onRefine(toSplit[d][i], newEntities[d][i]);
+
+  td = adapter->sizeField->getTransferDimension();
+  for (int d = td; d <= m->getDimension(); ++d)
+    for (size_t i = 0; i < toSplit[d].getSize(); ++i)
+      adapter->sizeField->onRefine(toSplit[d][i], newEntities[d][i]);
 }
 
 void FaceSplit::destroyOldElements()

--- a/ma/maRefine.cc
+++ b/ma/maRefine.cc
@@ -357,6 +357,13 @@ void transferElements(Refine* r)
       for (size_t i=0; i < r->toSplit[d].getSize(); ++i)
 	st->onRefine(r->toSplit[d][i],r->newEntities[d][i]);
   }
+  {
+    SizeField* sf = a->sizeField;
+    int td = sf->getTransferDimension();
+    for (int d = td; d <= m->getDimension(); ++d)
+      for (size_t i=0; i < r->toSplit[d].getSize(); ++i)
+	sf->onRefine(r->toSplit[d][i],r->newEntities[d][i]);
+  }
 }
 
 void forgetNewEntities(Refine* r)

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -153,7 +153,7 @@ class SizeFieldIntegrator : public apf::Integrator
 {
   public:
     SizeFieldIntegrator(SizeField* sF):
-      Integrator(2),
+      Integrator(3),
       measurement(0),
       sizeField(sF),
       meshElement(0),

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -21,6 +21,32 @@ SizeField::~SizeField()
 {
 }
 
+void SizeField::onRefine(Entity*, EntityArray&)
+{
+  PCU_ALWAYS_ASSERT_VERBOSE(0,
+      "unimplemented onRefine was called for a size-field!");
+}
+
+void SizeField::onCavity(EntityArray&, EntityArray&)
+{
+  PCU_ALWAYS_ASSERT_VERBOSE(0,
+      "unimplemented onCavity was called for a size-field!");
+}
+
+int SizeField::getTransferDimension()
+{
+  // By default there should be now size_field transfer.
+  // This is used in a loop to get the lowest dimension
+  // entities that require transfer. So something bigger
+  // than mesh dimension will ignore that loop
+  return 4;
+}
+
+bool SizeField::hasNodesOn(int)
+{
+  return false;
+}
+
 IdentitySizeField::IdentitySizeField(Mesh* m):
   mesh(m)
 {
@@ -66,25 +92,6 @@ double IdentitySizeField::getWeight(Entity*)
   return 1.0;
 }
 
-void IdentitySizeField::onRefine(Entity*, EntityArray&)
-{
-}
-
-void IdentitySizeField::onCavity(EntityArray&, EntityArray&)
-{
-}
-
-int IdentitySizeField::getTransferDimension()
-{
-  return 0;
-}
-
-bool IdentitySizeField::hasNodesOn(int dimension)
-{
-  std::ignore = (dimension);
-  return false;
-}
-
 static void orthogonalizeR(Matrix& R)
 {
   /* by the way, the principal direction vectors
@@ -116,14 +123,14 @@ static void orthogonalizeR(Matrix& R)
 
 static void orthogonalEigenDecompForSymmetricMatrix(Matrix const& A, Vector& v, Matrix& R)
 {
-  /* here we assume A to be real symmetric 3x3 matrix, 
+  /* here we assume A to be real symmetric 3x3 matrix,
    * we should be able to get 3 orthogonal eigen vectors
    * we also normalize the eigen vectors */
   double eigenValues[3];
   Vector eigenVectors[3];
-  
+
   apf::eigen(A, eigenVectors, eigenValues);
-  
+
   Matrix RT(eigenVectors); // eigen vectors are stored in the rows of RT
 
   RT[0] = RT[0].normalize();
@@ -432,21 +439,6 @@ struct AnisoSizeField : public MetricSizeField
                           0,1,0,
                           0,0,1),
                    Vector(value,value,value));
-  }
-  void onRefine(Entity*, EntityArray&)
-  {
-  }
-  void onCavity(EntityArray&, EntityArray&)
-  {
-  }
-  int getTransferDimension()
-  {
-    return 0;
-  }
-  bool hasNodesOn(int dimension)
-  {
-    std::ignore = (dimension);
-    return false;
   }
   apf::Field* hField;
   apf::Field* rField;

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -74,6 +74,11 @@ void IdentitySizeField::onCavity(EntityArray&, EntityArray&)
 {
 }
 
+int IdentitySizeField::getTransferDimension()
+{
+  return 0;
+}
+
 static void orthogonalizeR(Matrix& R)
 {
   /* by the way, the principal direction vectors
@@ -428,6 +433,10 @@ struct AnisoSizeField : public MetricSizeField
   void onCavity(EntityArray&, EntityArray&)
   {
   }
+  int getTransferDimension()
+  {
+    return 0;
+  }
   apf::Field* hField;
   apf::Field* rField;
   BothEval bothEval;
@@ -539,6 +548,16 @@ struct LogAnisoSizeField : public MetricSizeField
   {
     transfer(logMField, &(fieldVal[0]),
         oldElements.getSize(), &(oldElements[0]), newEntities);
+  }
+  int getTransferDimension()
+  {
+    int transferDimension = 4;
+    for (int d = 1; d <=3; d++)
+      if (apf::getShape(logMField)->hasNodesIn(d)) {
+        transferDimension = d;
+        break;
+      }
+    return transferDimension;
   }
   apf::NewArray<double> fieldVal;
   apf::Field* logMField;

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -9,6 +9,7 @@
 *******************************************************************************/
 #include <PCU.h>
 #include "maSize.h"
+#include "maSolutionTransferHelper.h"
 #include "apfMatrix.h"
 #include <apfShape.h>
 #include <cstdlib>
@@ -63,6 +64,14 @@ void IdentitySizeField::getTransform(
 double IdentitySizeField::getWeight(Entity*)
 {
   return 1.0;
+}
+
+void IdentitySizeField::onRefine(Entity*, EntityArray&)
+{
+}
+
+void IdentitySizeField::onCavity(EntityArray&, EntityArray&)
+{
 }
 
 static void orthogonalizeR(Matrix& R)
@@ -413,6 +422,12 @@ struct AnisoSizeField : public MetricSizeField
                           0,0,1),
                    Vector(value,value,value));
   }
+  void onRefine(Entity*, EntityArray&)
+  {
+  }
+  void onCavity(EntityArray&, EntityArray&)
+  {
+  }
   apf::Field* hField;
   apf::Field* rField;
   BothEval bothEval;
@@ -467,6 +482,7 @@ struct LogAnisoSizeField : public MetricSizeField
 	m->end(it);
       }
     }
+    fieldVal.allocate(apf::countComponents(logMField));
   }
   void getTransform(
       apf::MeshElement* me,
@@ -511,6 +527,20 @@ struct LogAnisoSizeField : public MetricSizeField
                           0,value,0,
                           0,0,value));
   }
+  void onRefine(
+      Entity* parent,
+      EntityArray& newEntities)
+  {
+    transfer(logMField, &(fieldVal[0]), 1, &parent, newEntities);
+  }
+  void onCavity(
+      EntityArray& oldElements,
+      EntityArray& newEntities)
+  {
+    transfer(logMField, &(fieldVal[0]),
+        oldElements.getSize(), &(oldElements[0]), newEntities);
+  }
+  apf::NewArray<double> fieldVal;
   apf::Field* logMField;
   LogMEval logMEval;
 };

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -229,7 +229,7 @@ struct MetricSizeField : public SizeField
     return measure(e) / parentMeasure[mesh->getType(e)];
   }
   Mesh* mesh;
-  int order; // this is the underlying sizefield order
+  int order; // this is the underlying sizefield order (default 1)
 };
 
 AnisotropicFunction::~AnisotropicFunction()
@@ -366,6 +366,8 @@ struct AnisoSizeField : public MetricSizeField
 {
   AnisoSizeField()
   {
+    mesh = 0;
+    order = 1;
   }
   AnisoSizeField(Mesh* m, AnisotropicFunction* f):
     bothEval(f),
@@ -455,6 +457,8 @@ struct LogAnisoSizeField : public MetricSizeField
 {
   LogAnisoSizeField()
   {
+    mesh = 0;
+    order = 1;
   }
   LogAnisoSizeField(Mesh* m, AnisotropicFunction* f):
     logMEval(f)

--- a/ma/maSize.cc
+++ b/ma/maSize.cc
@@ -35,7 +35,7 @@ void SizeField::onCavity(EntityArray&, EntityArray&)
 
 int SizeField::getTransferDimension()
 {
-  // By default there should be now size_field transfer.
+  // By default there should be no size_field transfer.
   // This is used in a loop to get the lowest dimension
   // entities that require transfer. So something bigger
   // than mesh dimension will ignore that loop

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -43,6 +43,7 @@ class SizeField
         EntityArray& oldElements,
         EntityArray& newEntities) = 0;
     virtual int getTransferDimension() = 0;
+    virtual bool hasNodesOn(int dimension) = 0;
 };
 
 struct IdentitySizeField : public SizeField
@@ -59,6 +60,7 @@ struct IdentitySizeField : public SizeField
           apf::MeshElement*,
           Vector const&,
           Matrix& t);
+  bool hasNodesOn(int dimension);
   double getWeight(Entity*);
   void onRefine(
       Entity* parent,

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -42,6 +42,7 @@ class SizeField
     virtual void onCavity(
         EntityArray& oldElements,
         EntityArray& newEntities) = 0;
+    virtual int getTransferDimension() = 0;
 };
 
 struct IdentitySizeField : public SizeField
@@ -65,6 +66,7 @@ struct IdentitySizeField : public SizeField
   void onCavity(
       EntityArray& oldElements,
       EntityArray& newEntities);
+  int getTransferDimension();
 
   Mesh* mesh;
 

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -36,6 +36,12 @@ class SizeField
         Vector const& xi,
         Matrix& t) = 0;
     virtual double getWeight(Entity* e) = 0;
+    virtual void onRefine(
+        Entity* parent,
+        EntityArray& newEntities) = 0;
+    virtual void onCavity(
+        EntityArray& oldElements,
+        EntityArray& newEntities) = 0;
 };
 
 struct IdentitySizeField : public SizeField
@@ -53,7 +59,14 @@ struct IdentitySizeField : public SizeField
           Vector const&,
           Matrix& t);
   double getWeight(Entity*);
+  virtual void onRefine(
+      Entity* parent,
+      EntityArray& newEntities);
+  virtual void onCavity(
+      EntityArray& oldElements,
+      EntityArray& newEntities);
   Mesh* mesh;
+
 };
 
 struct UniformRefiner : public IdentitySizeField

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -38,12 +38,12 @@ class SizeField
     virtual double getWeight(Entity* e) = 0;
     virtual void onRefine(
         Entity* parent,
-        EntityArray& newEntities) = 0;
+        EntityArray& newEntities);
     virtual void onCavity(
         EntityArray& oldElements,
-        EntityArray& newEntities) = 0;
-    virtual int getTransferDimension() = 0;
-    virtual bool hasNodesOn(int dimension) = 0;
+        EntityArray& newEntities);
+    virtual int getTransferDimension();
+    virtual bool hasNodesOn(int dimension);
 };
 
 struct IdentitySizeField : public SizeField
@@ -60,16 +60,7 @@ struct IdentitySizeField : public SizeField
           apf::MeshElement*,
           Vector const&,
           Matrix& t);
-  bool hasNodesOn(int dimension);
   double getWeight(Entity*);
-  void onRefine(
-      Entity* parent,
-      EntityArray& newEntities);
-  void onCavity(
-      EntityArray& oldElements,
-      EntityArray& newEntities);
-  int getTransferDimension();
-
   Mesh* mesh;
 
 };

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -42,7 +42,6 @@ class SizeField
     virtual void onCavity(
         EntityArray& oldElements,
         EntityArray& newEntities) = 0;
-    virtual void getTransferDimension() = 0;
 };
 
 struct IdentitySizeField : public SizeField

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -42,6 +42,7 @@ class SizeField
     virtual void onCavity(
         EntityArray& oldElements,
         EntityArray& newEntities) = 0;
+    virtual void getTransferDimension() = 0;
 };
 
 struct IdentitySizeField : public SizeField
@@ -59,12 +60,13 @@ struct IdentitySizeField : public SizeField
           Vector const&,
           Matrix& t);
   double getWeight(Entity*);
-  virtual void onRefine(
+  void onRefine(
       Entity* parent,
       EntityArray& newEntities);
-  virtual void onCavity(
+  void onCavity(
       EntityArray& oldElements,
       EntityArray& newEntities);
+
   Mesh* mesh;
 
 };

--- a/ma/maSolutionTransferHelper.cc
+++ b/ma/maSolutionTransferHelper.cc
@@ -1,0 +1,123 @@
+
+/*******************************************************************************
+
+opyright 2013 Scientific Computation Research Center, 
+      Rensselaer Polytechnic Institute. All rights reserved.
+  
+  The LICENSE file included with this distribution describes the terms
+  of the SCOREC Non-Commercial License this program is distributed under.
+ 
+*******************************************************************************/
+#include "maSolutionTransferHelper.h"
+#include "maAffine.h"
+#include "maMap.h"
+#include <apfShape.h>
+#include <apfNumbering.h>
+#include <float.h>
+
+namespace ma {
+
+int getMinimumDimension(apf::FieldShape* s)
+{
+  int transferDimension = 4;
+  for (int d=1; d <= 3; ++d)
+    if (s->hasNodesIn(d))
+    {
+      transferDimension = d;
+      break;
+    }
+  return transferDimension;
+}
+
+int getBestElement(
+    apf::Mesh* mesh,
+    int n,
+    apf::Element** elems,
+    Affine* elemInvMaps,
+    Vector const& point,
+    Vector& bestXi)
+{
+  double bestValue = -DBL_MAX;
+  int bestI = 0;
+  for (int i = 0; i < n; ++i)
+  {
+    Vector xi;
+    if (mesh->getShape()->getOrder() == 1)
+      xi = elemInvMaps[i] * point;
+    else
+      xi = curvedElemInvMap(mesh, apf::getMeshEntity(elems[i]), point);
+    double value = getInsideness(mesh,apf::getMeshEntity(elems[i]),xi);
+    if (value > bestValue)
+    {
+      bestValue = value;
+      bestI = i;
+      bestXi = xi;
+    }
+  }
+  return bestI;
+}
+
+void transferToNode(
+    apf::Field* field,
+    double *value,
+    int n,
+    apf::Element** elems,
+    Affine* elemInvMaps,
+    apf::Node const& node)
+{
+  apf::Mesh* mesh = apf::getMesh(field);
+  // first get the physical coordinate of the node
+  Vector xi;
+  Vector point;
+  apf::FieldShape* shape = apf::getShape(field);
+  shape->getNodeXi(mesh->getType(node.entity),node.node,xi);
+  if (mesh->getShape()->getOrder() == 1) { // if linear mesh use the affine
+    Affine childMap = getMap(mesh,node.entity);
+    point = childMap * xi;
+  }
+  else { // else inquire the physical coordinated of local coordinate xi
+    apf::MeshElement* me = apf::createMeshElement(mesh,node.entity);
+    apf::mapLocalToGlobal(me, xi, point);
+    apf::destroyMeshElement(me);
+  }
+  Vector elemXi;
+  int i = getBestElement(mesh,n,elems,elemInvMaps,point,elemXi);
+  apf::getComponents(elems[i],elemXi,value);
+  apf::setComponents(field,node.entity,node.node,value);
+}
+
+void transfer(
+    apf::Field* field,
+    double *value,
+    int n, // size of the cavity
+    Entity** cavity,
+    EntityArray& newEntities)
+{
+  apf::Mesh* mesh = apf::getMesh(field);
+  apf::FieldShape* shape = apf::getShape(field);
+  int minDim = getMinimumDimension(shape);
+  if (getDimension(mesh, cavity[0]) < minDim)
+    return;
+  apf::NewArray<apf::Element*> elems(n);
+  for (int i = 0; i < n; ++i)
+    elems[i] = apf::createElement(field,cavity[i]);
+  apf::NewArray<Affine> elemInvMaps(n);
+  for (int i = 0; i < n; ++i)
+    elemInvMaps[i] = invert(getMap(mesh,cavity[i]));
+  for (size_t i = 0; i < newEntities.getSize(); ++i)
+  {
+    int type = mesh->getType(newEntities[i]);
+    if (type == apf::Mesh::VERTEX)
+      continue; //vertices will have been handled specially beforehand
+    int nnodes = shape->countNodesOn(type);
+    for (int j = 0; j < nnodes; ++j)
+    {
+      apf::Node node(newEntities[i],j);
+      transferToNode(field, value,
+      	  n,&(elems[0]),&(elemInvMaps[0]),node);
+    }
+  }
+  for (int i = 0; i < n; ++i)
+    apf::destroyElement(elems[i]);
+}
+}

--- a/ma/maSolutionTransferHelper.h
+++ b/ma/maSolutionTransferHelper.h
@@ -1,0 +1,31 @@
+
+/*******************************************************************************
+
+Copyright 2013 Scientific Computation Research Center, 
+      Rensselaer Polytechnic Institute. All rights reserved.
+  
+  The LICENSE file included with this distribution describes the terms
+  of the SCOREC Non-Commercial License this program is distributed under.
+ 
+*******************************************************************************/
+
+#ifndef MA_SOLUTIONTRANSFERHELPER_H
+#define MA_SOLUTIONTRANSFERHELPER_H
+
+#include <apf.h>
+#include "maMesh.h"
+
+#include "maAffine.h"
+#include "maMap.h"
+
+namespace ma {
+int getMinimumDimension(apf::FieldShape* s);
+void transfer(
+    apf::Field* field,
+    double *value,
+    int n, // size of the cavity
+    Entity** cavity,
+    EntityArray& newEntities);
+}
+
+#endif

--- a/ma/pkg_tribits.cmake
+++ b/ma/pkg_tribits.cmake
@@ -22,6 +22,7 @@ set(SOURCES
   maLayerCollapse.cc
   maMatch.cc
   maSolutionTransfer.cc
+  maSolutionTransferHelper.cc
   maSnap.cc
   maEdgeSwap.cc
   maShape.cc

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -198,6 +198,7 @@ if(ENABLE_SIMMETRIX)
   test_exe_func(simZBalance simZBalance.cc)
   test_exe_func(crack_test crack_test.cc)
   test_exe_func(highOrderSolutionTransfer highOrderSolutionTransfer.cc)
+  test_exe_func(highOrderSizeFields highOrderSizeFields.cc)
 endif()
 
 # send all the newly added utility executable targets

--- a/test/highOrderSizeFields.cc
+++ b/test/highOrderSizeFields.cc
@@ -28,11 +28,6 @@ void computeSizesFrames(
     apf::Vector3 &sz,
     apf::Matrix3x3 &frm);
 
-void computeLogM(
-    const apf::Vector3& sz,
-    const apf::Matrix3x3& frm,
-    apf::Matrix3x3& logm);
-
 void testAdapt(
     const char* model,
     const char* mesh,
@@ -115,18 +110,6 @@ void computeSizesFrames(
   frm[2] = tangent;
 }
 
-void computeLogM(
-    const apf::Vector3& sz,
-    const apf::Matrix3x3& frm,
-    apf::Matrix3x3& logm)
-{
-  apf::Vector3 s(log(1./sz[0]/sz[0]), log(1./sz[1]/sz[1]), log(1./sz[2]/sz[2]));
-  apf::Matrix3x3 S(s[0],   0.,   0.,
-                     0., s[1],   0.,
-                     0.,   0., s[2]);
-  logm = frm * S * transpose(frm);
-}
-
 void testAdapt(
     const char* model,
     const char* mesh,
@@ -142,13 +125,6 @@ void testAdapt(
   apf::FieldShape* fs = apf::getH1Shape(order);
   apf::Field* sizes = apf::createField(m, "sizes", apf::VECTOR, fs);
   apf::Field* frames = apf::createField(m, "frames", apf::MATRIX, fs);
-
-  apf::Field* sizes_transfer = apf::createField(m, "sizest", apf::VECTOR,
-      apf::getH1Shape(order));
-  apf::Field* frames_transfer = apf::createField(m, "framest", apf::MATRIX,
-      apf::getH1Shape(order));
-  apf::Field* logm_transfer = apf::createField(m, "logmt", apf::MATRIX,
-      apf::getH1Shape(order));
 
   int dim = m->getDimension();
   apf::MeshEntity* ent;
@@ -171,12 +147,6 @@ void testAdapt(
 	computeSizesFrames(m, p, sz, frm);
 	apf::setVector(sizes, ent, i, sz);
 	apf::setMatrix(frames, ent, i, frm);
-
-        apf::setVector(sizes_transfer, ent, i, sz);
-        apf::setMatrix(frames_transfer, ent, i, frm);
-        apf::Matrix3x3 logm;
-        computeLogM(sz, frm, logm);
-        apf::setMatrix(logm_transfer, ent, i, logm);
       }
       apf::destroyMeshElement(me);
     }
@@ -198,15 +168,9 @@ void testAdapt(
 
   m->removeField(sizes);
   m->removeField(frames);
-  m->removeField(sizes_transfer);
-  m->removeField(frames_transfer);
-  m->removeField(logm_transfer);
 
   apf::destroyField(sizes);
   apf::destroyField(frames);
-  apf::destroyField(sizes_transfer);
-  apf::destroyField(frames_transfer);
-  apf::destroyField(logm_transfer);
 
   m->destroyNative();
   apf::destroyMesh(m);

--- a/test/highOrderSizeFields.cc
+++ b/test/highOrderSizeFields.cc
@@ -1,0 +1,213 @@
+#include <apf.h>
+#include <apfMDS.h>
+#include <apfShape.h>
+#include <apfField.h>
+#include <gmi_mesh.h>
+#include <ma.h>
+#include <maShape.h>
+#include <PCU.h>
+#include <crv.h>
+#include <lionPrint.h>
+#ifdef HAVE_SIMMETRIX
+#include <SimUtil.h>
+#include <MeshSim.h>
+#include <gmi_sim.h>
+#include <SimModel.h>
+#endif
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <math.h>
+
+
+void computeSizesFrames(
+    apf::Mesh2* m,
+    const apf::Vector3 &p,
+    apf::Vector3 &sz,
+    apf::Matrix3x3 &frm);
+
+void computeLogM(
+    const apf::Vector3& sz,
+    const apf::Matrix3x3& frm,
+    apf::Matrix3x3& logm);
+
+void testAdapt(
+    const char* model,
+    const char* mesh,
+    int order);
+
+int main(int argc, char** argv)
+{
+  MPI_Init(&argc, &argv);
+  PCU_Comm_Init();
+  lion_set_verbosity(1);
+
+#ifdef HAVE_SIMMETRIX
+  MS_init();
+  SimModel_start();
+  Sim_readLicenseFile(0);
+  gmi_sim_start();
+  gmi_register_sim();
+#endif
+  gmi_register_mesh();
+
+  if (argc != 3) {
+    if(0==PCU_Comm_Self())
+      std::cerr <<"usage: " << argv[0]
+      	<< " <model.smd> <mesh.smb> <sizefield>\n";
+    return EXIT_FAILURE;
+  }
+
+  for (int order = 3; order < 5; order++) {
+    if(0==PCU_Comm_Self())
+      lion_oprint(1, "Testing aniso adapt w/ sizefield order %d\n", order);
+    testAdapt(argv[1], argv[2], order);
+  }
+
+  PCU_Comm_Free();
+#ifdef HAVE_SIMMETRIX
+  gmi_sim_stop();
+  Sim_unregisterAllKeys();
+  SimModel_stop();
+  MS_exit();
+#endif
+  MPI_Finalize();
+}
+
+void computeSizesFrames(
+    apf::Mesh2* m,
+    const apf::Vector3 &p,
+    apf::Vector3 &sz,
+    apf::Matrix3x3 &frm)
+{
+  apf::Vector3 llb;
+  apf::Vector3 umb;
+  ma::getBoundingBox(m, llb, umb);
+  const double pi = 3.14152;
+  apf::Vector3 diff = umb - llb;
+  diff[1] = 0.0;
+  // total length in the direction of the wave
+  double length = diff.getLength();
+  // normal in the direction of the wave
+  apf::Vector3 normal = diff / length;
+  apf::Vector3 tangent(-normal[2], 0., normal[0]);
+
+  double maxSz = length / 12.;
+  double minSz = length / 200.;
+  double wavelength = length / 4.;
+
+
+  double alpha = (maxSz - minSz)/2.;
+  double beta =  (maxSz + minSz)/2.;
+
+  double s = normal * p;
+
+  sz = apf::Vector3(
+      length/4.,
+      length/4.,
+      beta + alpha * sin(2*pi*s/wavelength)
+      );
+
+  frm[0] = normal;
+  frm[1] = apf::Vector3(0., 1., 0.);
+  frm[2] = tangent;
+}
+
+void computeLogM(
+    const apf::Vector3& sz,
+    const apf::Matrix3x3& frm,
+    apf::Matrix3x3& logm)
+{
+  apf::Vector3 s(log(1./sz[0]/sz[0]), log(1./sz[1]/sz[1]), log(1./sz[2]/sz[2]));
+  apf::Matrix3x3 S(s[0],   0.,   0.,
+                     0., s[1],   0.,
+                     0.,   0., s[2]);
+  logm = frm * S * transpose(frm);
+}
+
+void testAdapt(
+    const char* model,
+    const char* mesh,
+    int order)
+{
+  gmi_model* g = gmi_load(model);
+  apf::Mesh2* m = apf::loadMdsMesh(g,mesh);
+  m->verify();
+
+  ma::Input* in = ma::configureUniformRefine(m, 1, 0);
+  ma::adapt(in);
+
+  apf::FieldShape* fs = apf::getH1Shape(order);
+  apf::Field* sizes = apf::createField(m, "sizes", apf::VECTOR, fs);
+  apf::Field* frames = apf::createField(m, "frames", apf::MATRIX, fs);
+
+  apf::Field* sizes_transfer = apf::createField(m, "sizest", apf::VECTOR,
+      apf::getH1Shape(order));
+  apf::Field* frames_transfer = apf::createField(m, "framest", apf::MATRIX,
+      apf::getH1Shape(order));
+  apf::Field* logm_transfer = apf::createField(m, "logmt", apf::MATRIX,
+      apf::getH1Shape(order));
+
+  int dim = m->getDimension();
+  apf::MeshEntity* ent;
+  apf::MeshIterator* it;
+
+  for (int d = 0; d <= dim; d++) {
+    if (!fs->countNodesOn(apf::Mesh::simplexTypes[d]))
+      continue;
+    it = m->begin(d);
+    while( (ent = m->iterate(it)) ) {
+      int type = m->getType(ent);
+      int non = fs->countNodesOn(type);
+      apf::MeshElement* me = apf::createMeshElement(m, ent);
+      for (int i = 0; i < non; i++) {
+	apf::Vector3 xi, p, value;
+	fs->getNodeXi(type, i, xi);
+	apf::mapLocalToGlobal(me, xi, p);
+	apf::Vector3 sz;
+	apf::Matrix3x3 frm;
+	computeSizesFrames(m, p, sz, frm);
+	apf::setVector(sizes, ent, i, sz);
+	apf::setMatrix(frames, ent, i, frm);
+
+        apf::setVector(sizes_transfer, ent, i, sz);
+        apf::setMatrix(frames_transfer, ent, i, frm);
+        apf::Matrix3x3 logm;
+        computeLogM(sz, frm, logm);
+        apf::setMatrix(logm_transfer, ent, i, logm);
+      }
+      apf::destroyMeshElement(me);
+    }
+    m->end(it);
+  }
+
+  in = ma::configure(m, sizes, frames, 0, true);
+  in->shouldFixShape = true;
+  in->maximumIterations = 10;
+  in->shouldForceAdaptation = true;
+
+  std::stringstream ss;
+  ss << "before_adapt_with_ho_sizefield_order_" << order;
+  apf::writeVtkFiles(ss.str().c_str(), m);
+  ss.str("");
+  ma::adaptVerbose(in);
+  ss << "after_adapt_with_ho_sizefield_order_" << order;
+  apf::writeVtkFiles(ss.str().c_str(), m);
+
+  m->removeField(sizes);
+  m->removeField(frames);
+  m->removeField(sizes_transfer);
+  m->removeField(frames_transfer);
+  m->removeField(logm_transfer);
+
+  apf::destroyField(sizes);
+  apf::destroyField(frames);
+  apf::destroyField(sizes_transfer);
+  apf::destroyField(frames_transfer);
+  apf::destroyField(logm_transfer);
+
+  m->destroyNative();
+  apf::destroyMesh(m);
+}

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -66,6 +66,10 @@ if(ENABLE_SIMMETRIX)
   mpi_test(modelInfo_smd 1
     ./modelInfo
     "${MESHES}/cube/cube.smd")
+  mpi_test(highorder_sizefield 1
+    ./highOrderSizeFields
+    "${MESHES}/cube/cube.smd"
+    "${MESHES}/cube/pumi11/cube.smb")
 endif(ENABLE_SIMMETRIX)
 
 if(ENABLE_SIMMETRIX)


### PR DESCRIPTION
This pull request includes the Implementation of higher order size fields for mesh adapt and the corresponding tests.

- [x] abstracts the transfer routines so that they can be used by size-field transfer routines as well
- [x] implementation of onRefine and onCavity for LogAnisoSizeField class
- [x] regression test for the above developments

