### PR TITLE
fixes issue #334

### DIFF
--- a/phasta/phIO.c
+++ b/phasta/phIO.c
@@ -81,7 +81,7 @@ static int find_header(FILE* f, const char* name, char* found, char header[PH_LI
     tmp[PH_LINE-1] = '\0';
     parse_header(tmp, &hname, &bytes, 0, NULL);
     if (!strncmp(name, hname, strlen(name))) {
-      strncpy(found, hname, strlen(hname));
+      strncpy(found, hname, strlen(found));
       found[strlen(hname)] = '\0';
       return 1;
     }


### PR DESCRIPTION
fixes the compiler error associated with the strnlen on the wrong
input of strncpy.

This needs testing/inspection from someone who is familiar with the Phasta use case.