### PR TITLE
Gcc11 fixes

### DIFF
--- a/ma/maStats.cc
+++ b/ma/maStats.cc
@@ -51,7 +51,7 @@ void getLinearQualitiesInPhysicalSpace(ma::Mesh* m,
   ma::Iterator* it;
   it = m->begin(m->getDimension());
   while( (e = m->iterate(it)) ) {
-    double lq;
+    double lq = 0;
     if (m->getType(e) == apf::Mesh::TRIANGLE) {
       ma::Vector p[3];
       ma::getVertPoints(m, e, p);

--- a/phasta/phIO.c
+++ b/phasta/phIO.c
@@ -81,7 +81,7 @@ static int find_header(FILE* f, const char* name, char* found, char header[PH_LI
     tmp[PH_LINE-1] = '\0';
     parse_header(tmp, &hname, &bytes, 0, NULL);
     if (!strncmp(name, hname, strlen(name))) {
-      strncpy(found, hname, strlen(hname));
+      strncpy(found, hname, strlen(found));
       found[strlen(hname)] = '\0';
       return 1;
     }

--- a/pumi/pumi_sys.cc
+++ b/pumi/pumi_sys.cc
@@ -103,7 +103,7 @@ double pumi_getMem()
   Kernel_GetMemorySize(KERNEL_MEMSIZE_HEAP, &heap);
   return (double)heap/M;
 #else
-  struct mallinfo meminfo_now = mallinfo();
+  struct mallinfo2 meminfo_now = mallinfo2();
   return ((double)meminfo_now.arena)/M;
 #endif
 }

--- a/test/describe.cc
+++ b/test/describe.cc
@@ -32,7 +32,7 @@ static double get_peak()
 
 static double get_peak()
 {
-  return mallinfo().arena;
+  return mallinfo2().arena;
 }
 
 #else
@@ -62,7 +62,7 @@ static void print_stats(const char* name, double value)
 
 static double get_chunks()
 {
-  struct mallinfo m = mallinfo();
+  struct mallinfo2 m = mallinfo2();
   return m.uordblks + m.hblkhd;
 }
 


### PR DESCRIPTION
Hi, I had some compilation errors with gcc 11.1.1 on Fedora 34. I fixed the compilation errors, mostly it was changing `mallinfo()` to `mallinfo2()`, which was introduced in February 21, so maybe you'll need a flag to distinguish between glibc 2.33 and older versions.