### PR TITLE
Options for mesh adapt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 # This is the top level CMake file for the SCOREC build
 cmake_minimum_required(VERSION 3.0)
 
-project(SCOREC VERSION 2.2.5 LANGUAGES CXX C)
+project(SCOREC VERSION 2.2.6 LANGUAGES CXX C)
 
 include(cmake/bob.cmake)
 include(cmake/xsdk.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,9 +120,6 @@ if(ENABLE_OMEGA_H)
   bob_public_dep(Omega_h)
 endif()
 
-if(ENABLE_ZOLTAN)
-  add_definitions(-DHAVE_ZOLTAN)
-endif()
 
 # Include the SCOREC project packages
 add_subdirectory(lion)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ if(ENABLE_OMEGA_H)
   bob_public_dep(Omega_h)
 endif()
 
+if(ENABLE_ZOLTAN)
+  add_definitions(-DHAVE_ZOLTAN)
+endif()
+
 # Include the SCOREC project packages
 add_subdirectory(lion)
 add_subdirectory(pcu)

--- a/ma/maBalance.cc
+++ b/ma/maBalance.cc
@@ -160,7 +160,7 @@ void preBalance(Adapt* a)
       (!in->shouldRunPreParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
 #ifdef PUMI_HAS_ZOLTAN
-    if (PCU_Comm_Peers() < 16000) {
+    if (PCU_Comm_Peers() < 16000) {  // the parmetis multi-level graph partitioner memory usage grows significantly with process count beyond 16K processes
       runZoltan(a);
       return;
     }

--- a/ma/maBalance.cc
+++ b/ma/maBalance.cc
@@ -121,17 +121,58 @@ void printEntityImbalance(Mesh* m)
   print("element imbalance %.0f%% of average",p);
 }
 
+double estimateWeightedImbalance(Adapt* a)
+{
+  Tag* w = getElementWeights(a);
+  double imb[4];
+  Parma_GetWeightedEntImbalance(a->mesh, w, &imb);
+  removeTagFromDimension(a->mesh, w, a->mesh->getDimension());
+  a->mesh->destroyTag(w);
+  return imb[a->mesh->getDimension()];
+}
+
 void preBalance(Adapt* a)
 {
   if (PCU_Comm_Peers()==1)
     return;
   Input* in = a->input;
-  if (in->shouldRunPreZoltan)
+  // First take care of user overrides. That is, if any of the three options
+  // is true, apply that balancer and return.
+  if (in->shouldRunPreZoltan) {
     runZoltan(a);
-  if (in->shouldRunPreZoltanRib)
+    return;
+  }
+  if (in->shouldRunPreZoltanRib) {
     runZoltan(a,apf::RIB);
-  if (in->shouldRunPreParma)
+    return;
+  }
+  if (in->shouldRunPreParma) {
     runParma(a);
+    return;
+  }
+
+  // Then, take care of the case where all the options are set to false.
+  // That is, if the default values have not changed by the user. In
+  // this case, we apply the best possible balancer, if weighted imbalance
+  // is bigger than in->maximumImbalance
+  if ((!in->shouldRunPreZoltan) &&
+      (!in->shouldRunPreZoltanRib) &&
+      (!in->shouldRunPreParma) &&
+      (estimateWeightedImbalance(a) > in->maximumImbalance)) {
+#ifdef HAVE_ZOLTAN
+    if (PCU_Comm_Peers() < 16000) {
+      runZoltan(a);
+      return;
+    }
+    else {
+      runZoltan(a, apf::RIB);
+      return;
+    }
+#else
+    runParma(a);
+    return;
+#endif
+  }
 }
 
 void midBalance(Adapt* a)
@@ -139,10 +180,37 @@ void midBalance(Adapt* a)
   if (PCU_Comm_Peers()==1)
     return;
   Input* in = a->input;
-  if (in->shouldRunMidZoltan)
+  // First take care of user overrides. That is, if any of the three options
+  // is true, apply that balancer and return.
+  if (in->shouldRunMidZoltan) {
     runZoltan(a);
-  if (in->shouldRunMidParma)
+    return;
+  }
+  if (in->shouldRunMidParma) {
     runParma(a);
+    return;
+  }
+  // Then, take care of the case where all the options are set to false.
+  // That is, if the default values have not changed by the user. In
+  // this case, we apply the best possible balancer, if weighted imbalance
+  // is bigger than in->maximumImbalance
+  if ((!in->shouldRunMidZoltan) &&
+      (!in->shouldRunMidParma) &&
+      (estimateWeightedImbalance(a) > in->maximumImbalance)) {
+#ifdef HAVE_ZOLTAN
+    if (PCU_Comm_Peers() < 16000) {
+      runZoltan(a);
+      return;
+    }
+    else {
+      runZoltan(a, apf::RIB);
+      return;
+    }
+#else
+    runParma(a);
+    return;
+#endif
+  }
 }
 
 void postBalance(Adapt* a)
@@ -150,13 +218,48 @@ void postBalance(Adapt* a)
   if (PCU_Comm_Peers()==1)
     return;
   Input* in = a->input;
-  if (in->shouldRunPostZoltan)
+  // First take care of user overrides. That is, if any of the three options
+  // is true, apply that balancer and return.
+  if (in->shouldRunPostZoltan) {
     runZoltan(a);
-  if (in->shouldRunPostZoltanRib)
+    printEntityImbalance(a->mesh);
+    return;
+  }
+  if (in->shouldRunPostZoltanRib) {
     runZoltan(a,apf::RIB);
-  if (in->shouldRunPostParma)
+    printEntityImbalance(a->mesh);
+    return;
+  }
+  if (in->shouldRunPostParma) {
     runParma(a);
-  printEntityImbalance(a->mesh);
+    printEntityImbalance(a->mesh);
+    return;
+  }
+  // Then, take care of the case where all the options are set to false.
+  // That is, if the default values have not changed by the user. In
+  // this case, we apply the best possible balancer, if weighted imbalance
+  // is bigger than in->maximumImbalance
+  if ((!in->shouldRunPostZoltan) &&
+      (!in->shouldRunPostZoltanRib) &&
+      (!in->shouldRunPostParma) &&
+      (estimateWeightedImbalance(a) > in->maximumImbalance)) {
+#ifdef HAVE_ZOLTAN
+    if (PCU_Comm_Peers() < 16000) {
+      runZoltan(a);
+      printEntityImbalance(a->mesh);
+      return;
+    }
+    else {
+      runZoltan(a, apf::RIB);
+      printEntityImbalance(a->mesh);
+      return;
+    }
+#else
+    runParma(a);
+    printEntityImbalance(a->mesh);
+    return;
+#endif
+  }
 }
 
 }

--- a/ma/maBalance.cc
+++ b/ma/maBalance.cc
@@ -159,7 +159,7 @@ void preBalance(Adapt* a)
       (!in->shouldRunPreZoltanRib) &&
       (!in->shouldRunPreParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
-#ifdef HAVE_ZOLTAN
+#ifdef PUMI_HAS_ZOLTAN
     if (PCU_Comm_Peers() < 16000) {
       runZoltan(a);
       return;
@@ -197,7 +197,7 @@ void midBalance(Adapt* a)
   if ((!in->shouldRunMidZoltan) &&
       (!in->shouldRunMidParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
-#ifdef HAVE_ZOLTAN
+#ifdef PUMI_HAS_ZOLTAN
     if (PCU_Comm_Peers() < 16000) {
       runZoltan(a);
       return;
@@ -243,7 +243,7 @@ void postBalance(Adapt* a)
       (!in->shouldRunPostZoltanRib) &&
       (!in->shouldRunPostParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
-#ifdef HAVE_ZOLTAN
+#ifdef PUMI_HAS_ZOLTAN
     if (PCU_Comm_Peers() < 16000) {
       runZoltan(a);
       printEntityImbalance(a->mesh);

--- a/ma/maBalance.cc
+++ b/ma/maBalance.cc
@@ -4,6 +4,8 @@
 #include <parma.h>
 #include <apfZoltan.h>
 
+#define MAX_ZOLTAN_GRAPH_RANKS 16*1024
+
 namespace ma {
 
 static double clamp(double x, double max, double min)
@@ -160,7 +162,9 @@ void preBalance(Adapt* a)
       (!in->shouldRunPreParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
 #ifdef PUMI_HAS_ZOLTAN
-    if (PCU_Comm_Peers() < 16000) {  // the parmetis multi-level graph partitioner memory usage grows significantly with process count beyond 16K processes
+    // The parmetis multi-level graph partitioner memory usage grows
+    // significantly with process count beyond 16K processes
+    if (PCU_Comm_Peers() < MAX_ZOLTAN_GRAPH_RANKS) {
       runZoltan(a);
       return;
     }
@@ -198,7 +202,9 @@ void midBalance(Adapt* a)
       (!in->shouldRunMidParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
 #ifdef PUMI_HAS_ZOLTAN
-    if (PCU_Comm_Peers() < 16000) {
+    // The parmetis multi-level graph partitioner memory usage grows
+    // significantly with process count beyond 16K processes
+    if (PCU_Comm_Peers() < MAX_ZOLTAN_GRAPH_RANKS) {
       runZoltan(a);
       return;
     }
@@ -244,7 +250,9 @@ void postBalance(Adapt* a)
       (!in->shouldRunPostParma) &&
       (estimateWeightedImbalance(a) > in->maximumImbalance)) {
 #ifdef PUMI_HAS_ZOLTAN
-    if (PCU_Comm_Peers() < 16000) {
+    // The parmetis multi-level graph partitioner memory usage grows
+    // significantly with process count beyond 16K processes
+    if (PCU_Comm_Peers() < MAX_ZOLTAN_GRAPH_RANKS) {
       runZoltan(a);
       printEntityImbalance(a->mesh);
       return;

--- a/ma/maInput.cc
+++ b/ma/maInput.cc
@@ -148,7 +148,7 @@ void validateInput(Input* in)
     rejectInput("only one of Zoltan, ZoltanRib, and Parma PostBalance options can be set to true!");
   if (in->shouldRunMidZoltan && in->shouldRunMidParma)
     rejectInput("only one of Zoltan and Parma MidBalance options can be set to true!");
-#ifndef HAVE_ZOLTAN
+#ifndef PUMI_HAS_ZOLTAN
   if (in->shouldRunPreZoltan ||
       in->shouldRunPreZoltanRib ||
       in->shouldRunMidZoltan)

--- a/ma/maInput.cc
+++ b/ma/maInput.cc
@@ -78,6 +78,18 @@ void rejectInput(const char* str)
   abort();
 }
 
+// if more than 1 option is true return true
+static bool moreThanOneOptionIsTrue(bool op1, bool op2, bool op3)
+{
+  int cnt = 0;
+  if (op1) cnt++;
+  if (op2) cnt++;
+  if (op3) cnt++;
+  if (cnt > 1)
+    return true;
+  return false;
+}
+
 void validateInput(Input* in)
 {
   if ( ! in->sizeField)

--- a/ma/maInput.h
+++ b/ma/maInput.h
@@ -41,7 +41,11 @@ class Input
     SolutionTransfer* solutionTransfer;
     bool ownsSolutionTransfer;
     ShapeHandlerFunction shapeHandler;
-/** \brief number of refine/coarsen iterations to run (default 3) */
+/** \brief number of refine/coarsen iterations to run (default 3)
+    \details this value will be set to the minimum required iterations
+    inside the call to ma::configure in cases where there is a size information.
+    Users can override this by setting in->maximumIterations after the
+    call to ma::configure and before the call to ma::adapt routine.*/
     int maximumIterations;
 /** \brief whether to perform the collapse step */
     bool shouldCoarsen;
@@ -49,10 +53,10 @@ class Input
     \details requires modeler support, see gmi_can_eval */
     bool shouldSnap;
 /** \brief whether to transfer parametric coordinates
-  \details requires modeler support, see gmi_reparam */
+    \details requires modeler support, see gmi_reparam */
     bool shouldTransferParametric;
 /** \brief whether to transfer to the parametric coords of the closest point
-  \details requires modeler support, see gmi_closest_point */
+    \details requires modeler support, see gmi_closest_point */
     bool shouldTransferToClosestPoint;
 /** \brief whether to update matched entity info (limited support) */
     bool shouldHandleMatching;
@@ -63,35 +67,51 @@ class Input
 /** \brief whether to print the worst shape quality */
     bool shouldPrintQuality;
 /** \brief minimum desired mean ratio cubed for simplex elements
-   \details a different measure is used for curved elements */
+    \details a different measure is used for curved elements */
     double goodQuality;
 /** \brief whether to check the quality of split elems in DoubleSplitsCollapse
-   (default false) */
+    (default false) */
     double shouldCheckQualityForDoubleSplits;
 /** \brief minimum valid mean ratio cubed for simplex elements (default 1e-10)
-   \details used to define inside-out tetrahedra.
-   a different measure is used for curved elements */
+    \details used to define inside-out tetrahedra.
+    a different measure is used for curved elements */
     double validQuality;
 /** \brief imbalance target for all load balancing tools (default 1.10) */
     double maximumImbalance;
-/** \brief whether to run zoltan predictive load balancing (default false) */
+/** \brief whether to run zoltan predictive load balancing (default false)
+    \details if this and all the other PreBalance options are false, pre-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPreZoltan;
-/** \brief whether to run zoltan predictive load balancing using RIB (default false) */
+/** \brief whether to run zoltan predictive load balancing using RIB (default false)
+    \details if this and all the other PreBalance options are false, pre-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPreZoltanRib;
-/** \brief whether to run parma predictive load balancing (default false) */
+/** \brief whether to run parma predictive load balancing (default false)
+    \details if this and all the other PreBalance options are false, pre-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPreParma;
-/** \brief whether to run zoltan during adaptation (default false) */
+/** \brief whether to run zoltan during adaptation (default false)
+    \details if this and all the other MidBalance options are false, mid-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunMidZoltan;
-/** \brief whether to run parma during adaptation (default false)*/
+/** \brief whether to run parma during adaptation (default false)
+    \details if this and all the other MidBalance options are false, mid-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunMidParma;
-/** \brief whether to run zoltan after adapting (default false) */
+/** \brief whether to run zoltan after adapting (default false)
+    \details if this and all the other PostBalance options are false, post-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPostZoltan;
-/** \brief whether to run zoltan RIB after adapting (default false) */
+/** \brief whether to run zoltan RIB after adapting (default false)
+    \details if this and all the other PostBalance options are false, post-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPostZoltanRib;
-/** \brief whether to run parma after adapting (default false) */
+/** \brief whether to run parma after adapting (default false)
+    \details if this and all the other PostBalance options are false, post-balancing
+    occurs only if the imbalance is greater than in->maximumImbalance */
     bool shouldRunPostParma;
 /** \brief the ratio between longest and shortest edges that differentiates a
-   "short edge" element from a "large angle" element. */
+    "short edge" element from a "large angle" element. */
     double maximumEdgeRatio;
 /** \brief whether to tetrahedronize the boundary layer (default false)  */
     bool shouldTurnLayerToTets;

--- a/test/refine2x.cc
+++ b/test/refine2x.cc
@@ -104,8 +104,11 @@ int main(int argc, char** argv)
   ma::Mesh* m = apf::loadMdsMesh(argv[1],argv[2]);
   AnisotropicX* ansx = new AnisotropicX(m, atoi(argv[3]));
   ma::Input* in = ma::configure(m, ansx);
+#ifdef HAVE_ZOLTAN
   in->shouldRunPreZoltanRib = true;
+#else
   in->shouldRunPreParma = true;
+#endif
   in->shouldRunMidParma = true;
   in->shouldRunPostParma = true;
   in->maximumIterations = 10;

--- a/test/refine2x.cc
+++ b/test/refine2x.cc
@@ -104,7 +104,7 @@ int main(int argc, char** argv)
   ma::Mesh* m = apf::loadMdsMesh(argv[1],argv[2]);
   AnisotropicX* ansx = new AnisotropicX(m, atoi(argv[3]));
   ma::Input* in = ma::configure(m, ansx);
-#ifdef HAVE_ZOLTAN
+#ifdef PUMI_HAS_ZOLTAN
   in->shouldRunPreZoltanRib = true;
 #else
   in->shouldRunPreParma = true;

--- a/test/torus_ma_test.cc
+++ b/test/torus_ma_test.cc
@@ -56,10 +56,14 @@ int main(int argc, char** argv)
   apf::writeVtkFiles("torus_before",m);
   CylindricalShock sf(m);
   ma::Input* in = ma::configure(m, &sf);
+  // Note that the optimal number of iterations will be set
+  // inside the call to ma::configure above. However for this
+  // test we override this value to 3 to reduce the run time of
+  // test.
+  in->maximumIterations = 3;
   in->shouldRunPreZoltan = true;
   in->shouldRunMidParma = true;
   in->shouldRunPostParma = true;
-  in->shouldRefineLayer = true;
   ma::adapt(in);
   m->verify();
   apf::writeVtkFiles("torus_after",m);

--- a/zoltan/CMakeLists.txt
+++ b/zoltan/CMakeLists.txt
@@ -63,6 +63,7 @@ if(ENABLE_ZOLTAN)
     ${ZOLTAN_LIBRARIES}
     ${PARMETIS_LIBRARIES}
   )
+  target_compile_definitions(apf_zoltan PUBLIC PUMI_HAS_ZOLTAN)
 endif()
 
 scorec_export_library(apf_zoltan)


### PR DESCRIPTION
This pull request includes a couple of logic for setting mesh adapt options. In particular,

1. logic to compute `in->maximumIterations` based on the requested size field and current mesh size.
2. logic to invoke Pre, Post, or Mid balancer if the mesh imbalance becomes larger than `in->maximumImbalance` during mesh adapt.