### PR TITLE
require cxx11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" NO)
 
 #requre c++11 without extensions
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSION "NO")
+set(CMAKE_CXX_EXTENSION OFF)
 set(CMAKE_CXX_STANDARD 11)
 
 xsdk_begin_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,12 @@ project(SCOREC VERSION 2.2.6 LANGUAGES CXX C)
 include(cmake/bob.cmake)
 include(cmake/xsdk.cmake)
 
-option(SCOREC_ENABLE_CXX11 "enable compilation with c++11 support" NO)
-
 option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" NO)
+
+#requre c++11 without extensions
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSION "NO")
+set(CMAKE_CXX_STANDARD 11)
 
 xsdk_begin_package()
 bob_begin_package()
@@ -28,9 +31,6 @@ if(NOT USE_XSDK_DEFAULTS)
   bob_begin_cxx_flags()
   bob_end_cxx_flags()
   set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
-  if(SCOREC_ENABLE_CXX11)
-    bob_cxx11_flags()
-  endif()
 endif()
 message(STATUS "CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ add_subdirectory(omega_h)
 # this INTERFACE target bundles all the enabled libraries together
 add_library(core INTERFACE)
 target_link_libraries(core INTERFACE ${SCOREC_EXPORTED_TARGETS})
+target_compile_features(core INTERFACE cxx_std_11)
 scorec_export_library(core)
 
 #check for mallinfo2


### PR DESCRIPTION
Tested compilers

- [x]  gcc 8.2 (on cooley)
- [x] clang 7 (on aimos)
- [x] intel (19.0.1 on cranium)
- [x] pgi/nvhpc 20.11 (on aimos)
- [x] xl 16 (on aimos)

Documentation update
- [x] https://github.com/SCOREC/core/wiki/General-Build-instructions - no changes needed, we didn't list the CXX11 option

needed for #344