### PR TITLE
fixes for memory leaks mentioned in #344

### DIFF
--- a/crv/crvVtk.cc
+++ b/crv/crvVtk.cc
@@ -949,7 +949,7 @@ static void makeDirectories(const char* prefix, int type, int n)
 
 void writeCurvedWireFrame(apf::Mesh* m, int n, const char* prefix)
 {
-  apf::Mesh2* wireMesh = apf::makeEmptyMdsMesh(0, 1, false);
+  apf::Mesh2* wireMesh = apf::makeEmptyMdsMesh(NULL, 1, false);
   apf::Field* f = m->getCoordinateField();
   apf::MeshEntity* ent;
   apf::MeshIterator* it;
@@ -991,16 +991,13 @@ void writeCurvedWireFrame(apf::Mesh* m, int n, const char* prefix)
     }
     count++;
   }
-  // wireMesh is not a valid mesh, so neither of the following will work!
-  /* apf::deriveMdsModel(wireMesh); */
-  /* wireMesh->acceptChanges(); */
-  /* wireMesh->verify(); */
+  m->end(it);
   apf::printStats(wireMesh);
   std::stringstream ss;
   ss << prefix << "_wire";
   apf::writeVtkFiles(ss.str().c_str(),wireMesh);
-  /* wireMesh->destroyNative(); */
-  /* apf::destroyMesh(wireMesh); */
+  wireMesh->destroyNative();
+  apf::destroyMesh(wireMesh);
 }
 
 

--- a/ma/maSnap.cc
+++ b/ma/maSnap.cc
@@ -220,7 +220,12 @@ static Vector getInvSphere(const Vector& x)
   double phi = atan2(x[1], x[0]);
   if (phi < 0)
     phi = phi + 2 * M_PI;
-  double the = acos(x[2]);
+  // the following 3 lines are to avoid errors
+  // caused by floating point operations
+  double x2 = x[2];
+  if (x2 > 1.0) x2 = 1.0;
+  if (x2 < -1.0) x2 = -1.0;
+  double the = acos(x2);
   Vector res(phi, the, 0.0);
   return res;
 }

--- a/mds/apfMDS.cc
+++ b/mds/apfMDS.cc
@@ -600,7 +600,7 @@ class MeshMDS : public Mesh2
       apf::destroyField(coordinateField);
       coordinateField = 0;
       gmi_model* model = static_cast<gmi_model*>(mesh->user_model);
-      if (ownsModel)
+      if (ownsModel && model)
         gmi_destroy(model);
       mds_apf_destroy(mesh);
       mesh = 0;

--- a/test/collapse.cc
+++ b/test/collapse.cc
@@ -60,6 +60,8 @@ int main(int argc, char** argv) {
   code.mesh = apf::loadMdsMesh(modelFile, meshFile);
   apf::Unmodulo outMap(PCU_Comm_Self(), PCU_Comm_Peers());
   Parma_ShrinkPartition(code.mesh, partitionFactor, code);
+  code.mesh->destroyNative();
+  apf::destroyMesh(code.mesh);
 #ifdef HAVE_SIMMETRIX
   gmi_sim_stop();
   Sim_unregisterAllKeys();

--- a/test/highOrderSolutionTransfer.cc
+++ b/test/highOrderSolutionTransfer.cc
@@ -159,7 +159,7 @@ double testH1Field(
 
   int dim = m->getDimension();
   int count;
-  apf::MeshIterator* it = m->begin(0);
+  apf::MeshIterator* it;
   apf::MeshEntity* ent;
 
   // Verify that interpolated solution field agrees with exact field.

--- a/test/residualErrorEstimation_test.cc
+++ b/test/residualErrorEstimation_test.cc
@@ -155,6 +155,9 @@ double computeElementExactError(apf::Mesh* mesh, apf::MeshEntity* e,
   if (error < 0.0)
     error = -error;
 
+  apf::destroyElement(el);
+  apf::destroyMeshElement(me);
+
   return sqrt(error);
 }
 

--- a/test/rm_extrusion.cc
+++ b/test/rm_extrusion.cc
@@ -135,6 +135,7 @@ int main(int argc, char** argv)
 
   M_release(sim_mesh);
   Progress_delete(progress);
+  gmi_destroy(mdl);
   gmi_sim_stop();
   SimPartitionedMesh_stop();
   Sim_unregisterAllKeys();

--- a/test/serialize.cc
+++ b/test/serialize.cc
@@ -50,6 +50,8 @@ int main( int argc, char* argv[])
   code.meshFile = argv[3];
   apf::Unmodulo outMap(PCU_Comm_Self(), PCU_Comm_Peers());
   Parma_ShrinkPartition(code.mesh, atoi(argv[4]), code);
+  code.mesh->destroyNative();
+  apf::destroyMesh(code.mesh);
 #ifdef HAVE_SIMMETRIX
   gmi_sim_stop();
   Sim_unregisterAllKeys();

--- a/test/test_matrix_grad.cc
+++ b/test/test_matrix_grad.cc
@@ -114,6 +114,8 @@ int main(int argc, char* argv[])
   check_matrix_deriv->process(mesh);
   delete check_matrix_deriv;
   std::cout<<"Done"<<std::endl;
+  mesh->destroyNative();
+  apf::destroyMesh(mesh);
   PCU_Comm_Free();
   MPI_Finalize();
   return 0;


### PR DESCRIPTION
This PR addresses the memory leaks mentioned in https://github.com/SCOREC/core/pull/344 , using gcc10 and address-sanitizer

The following tests are not fixed yet

```
	 24 - chef-BL_query (Failed)
	 26 - rm_extrusion (Failed)
	 27 - cut_interface_sim (Failed)
	 31 - ph_adapt (Failed)
	 59 - collapse_2 (Failed)
	 62 - pipe_condense (Failed)
	 84 - ptnParma_cube (Failed)
	112 - parallel_meshgen (Failed)
	113 - parallel_meshgen_surf (Failed)
	114 - parallel_meshgen_vol (Failed)
	115 - parallel_meshgen_para (Failed)
	122 - degen_shpere_full (Failed)
	126 - chefStream (Failed)

```