### PR TITLE
Add release build to github workflow

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,40 +7,39 @@ on:
 jobs:
   build:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        compiler: [g++, clang++]
+        compiler:
+          - { compiler: GNU, CC: gcc-10, CXX: g++-10 }
+          - { compiler: LLVM, CC: clang, CXX: clang++ }
+        build_type: [Debug, Release]
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: recursive
     
-    - name: install mpich
-      run: sudo apt install mpich
-
-    - name: Create Build Environment
-      run: cmake -E make_directory ${{runner.workspace}}/build
-
-    - name: download meshes
-      run: git submodule init && git submodule update
+    - name: install mpich and gcc
+      run: |
+           sudo apt update
+           sudo apt install gcc-10 g++-10 mpich
 
     - name: Configure CMake
-      shell: bash
-      working-directory: ${{runner.workspace}}/build
-      run: export MPICXX=${{ matrix.compiler }} && 
-           cmake $GITHUB_WORKSPACE
-           -DCMAKE_CXX_COMPILER=mpicxx
-           -DCMAKE_C_COMPILER=mpicc
-           -DCMAKE_VERBOSE_MAKEFILE=on
-           -DMESHES=${GITHUB_WORKSPACE}/pumi-meshes
-           -DIS_TESTING=ON
+      env:
+        MPICH_CXX: ${{matrix.compiler.CXX}}
+        MPICH_CC: ${{matrix.compiler.CC}}
+      run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_VERBOSE_MAKEFILE=ON -DMESHES=${{github.workspace}}/pumi-meshes -DIS_TESTING=ON -DCMAKE_BUILD_TYPE=${{matrix.build_type}}
 
     - name: Build
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: cmake --build .
+      env:
+        MPICH_CXX: ${{matrix.compiler.CXX}}
+        MPICH_CC: ${{matrix.compiler.CC}}
+      run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} -j
 
     - name: Test
-      working-directory: ${{runner.workspace}}/build
-      shell: bash
-      run: ctest --output-on-failure
+      env:
+        MPICH_CXX: ${{matrix.compiler.CXX}}
+        MPICH_CC: ${{matrix.compiler.CC}}
+      working-directory: ${{github.workspace}}/build
+      run: ctest --output-on-failure -C ${{matrix.build_type}}

--- a/cmake/bob.cmake
+++ b/cmake/bob.cmake
@@ -1,3 +1,4 @@
+include(GNUInstallDirs)
 function(bob_always_full_rpath)
   # CMake RPATH "always full" configuration, see:
   # https://cmake.org/Wiki/CMake_RPATH_handling#Always_full_RPATH
@@ -6,12 +7,17 @@ function(bob_always_full_rpath)
   # when building, don't use the install RPATH already
   # (but later on when installing)
   set(CMAKE_BUILD_WITH_INSTALL_RPATH False PARENT_SCOPE)
-  # the RPATH to be used when installing, but only if it's not a system directory
-  list(FIND CMAKE_PLATFORM_IMPLICIT_LINK_DIRECTORIES
-       "${CMAKE_INSTALL_PREFIX}/lib" isSystemDir)
-  if("${isSystemDir}" STREQUAL "-1")
-    set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib" PARENT_SCOPE)
+
+  if(APPLE)
+      set(base @loader_path)
+  else()
+      set(base $ORIGIN)
   endif()
+  file(RELATIVE_PATH relDir
+       ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
+       ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
+  )
+  set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir} PARENT_SCOPE)
   # add the automatically determined parts of the RPATH
   # which point to directories outside the build tree to the install RPATH
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH True PARENT_SCOPE)

--- a/test/smokeTesting.cmake
+++ b/test/smokeTesting.cmake
@@ -20,7 +20,8 @@ smoke_test(split_2 2
   "pipe_2_.smb"
   2)
 
+include(GNUInstallDirs)
 # install the test input files for use in spack post-install tests
 install(FILES "${MDIR}/pipe.dmg" "${MDIR}/pipe0.smb"
-        DESTINATION ${CMAKE_INSTALL_PREFIX}/testdata)
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/testdata)
 


### PR DESCRIPTION
## Adding release build to GitHub actions

see issue #358 . The current release build fails, but the GitHub actions tests are passing. To make sure we notice these issues cropping up I have (attempted) to add a release build to the GitHub actions workflow.
