### PR TITLE
Enable PCU to work without global/singleton data

### DIFF
--- a/pcu/CMakeLists.txt
+++ b/pcu/CMakeLists.txt
@@ -28,6 +28,7 @@ set(SOURCES
 # Package headers
 set(HEADERS
   PCU.h
+  PCU2.h
   pcu_io.h
   pcu_util.h
   reel/reel.h

--- a/pcu/CMakeLists.txt
+++ b/pcu/CMakeLists.txt
@@ -10,6 +10,7 @@ message(STATUS "PCU_COMPRESS: " ${PCU_COMPRESS})
 # Package sources
 set(SOURCES
   pcu.c
+  pcu2.c
   pcu_aa.c
   pcu_coll.c
   pcu_io.c

--- a/pcu/PCU2.h
+++ b/pcu/PCU2.h
@@ -1,0 +1,137 @@
+/****************************************************************************** 
+
+  Copyright 2011 Scientific Computation Research Center, 
+      Rensselaer Polytechnic Institute. All rights reserved.
+  
+  This work is open source software, licensed under the terms of the
+  BSD license as described in the LICENSE file in the top-level directory.
+
+*******************************************************************************/
+#ifndef PCU2_H
+#define PCU2_H
+
+#define PCU_SUCCESS 0
+#define PCU_FAILURE -1
+
+#include <mpi.h>
+
+#ifdef __cplusplus
+#include <cstddef>
+#include <cstdio>
+extern "C" {
+#else
+#include <stddef.h>
+#include <stdio.h>
+#include <stdbool.h>
+#endif
+
+// FOR pcu_state_type ... use opaque ptr instead?
+#include "pcu_msg.h"
+
+typedef enum { pcu_state_uninit, pcu_state_init } pcu_state_enum ;
+typedef struct {
+  pcu_state_enum state;
+  pcu_msg pmsg;
+  pcu_mpi_t mpi;
+} pcu_t;
+
+/*library init/finalize*/
+int PCU_Comm_Init_2(pcu_t* pcu);
+int PCU_Comm_Free_2(pcu_t* pcu);
+
+/*rank/size functions*/
+int PCU_Comm_Self_2(pcu_t* pcu);
+int PCU_Comm_Peers_2(pcu_t* pcu);
+
+/*recommended message passing API*/
+void PCU_Comm_Begin_2(pcu_t* pcu);
+int PCU_Comm_Pack_2(pcu_t* pcu, int to_rank, const void* data, size_t size);
+int PCU_Comm_Send_2(pcu_t* pcu);
+bool PCU_Comm_Receive_2(pcu_t* pcu);
+bool PCU_Comm_Listen_2(pcu_t* pcu);
+int PCU_Comm_Sender_2(pcu_t* pcu);
+bool PCU_Comm_Unpacked_2(pcu_t* pcu);
+int PCU_Comm_Unpack_2(pcu_t* pcu, void* data, size_t size);
+
+/*turns deterministic ordering for the
+  above API on/off*/
+void PCU_Comm_Order_2(pcu_t* pcu, bool on);
+
+/*collective operations*/
+void PCU_Barrier_2(pcu_t* pcu);
+void PCU_Add_Doubles_2(pcu_t* pcu, double* p, size_t n);
+double PCU_Add_Double_2(pcu_t* pcu, double x);
+void PCU_Min_Doubles_2(pcu_t* pcu, double* p, size_t n);
+double PCU_Min_Double_2(pcu_t* pcu, double x);
+void PCU_Max_Doubles_2(pcu_t* pcu, double* p, size_t n);
+double PCU_Max_Double_2(pcu_t* pcu, double x);
+void PCU_Add_Ints_2(pcu_t* pcu, int* p, size_t n);
+int PCU_Add_Int_2(pcu_t* pcu, int x);
+void PCU_Add_Longs_2(pcu_t* pcu, long* p, size_t n);
+long PCU_Add_Long_2(pcu_t* pcu, long x);
+void PCU_Exscan_Ints_2(pcu_t* pcu, int* p, size_t n);
+int PCU_Exscan_Int_2(pcu_t* pcu, int x);
+void PCU_Exscan_Longs_2(pcu_t* pcu, long* p, size_t n);
+long PCU_Exscan_Long_2(pcu_t* pcu, long x);
+void PCU_Add_SizeTs_2(pcu_t* pcu, size_t* p, size_t n);
+size_t PCU_Add_SizeT_2(pcu_t* pcu, size_t x);
+void PCU_Min_SizeTs_2(pcu_t* pcu, size_t* p, size_t n);
+size_t PCU_Min_SizeT_2(pcu_t* pcu, size_t x);
+void PCU_Max_SizeTs_2(pcu_t* pcu, size_t* p, size_t n);
+size_t PCU_Max_SizeT_2(pcu_t* pcu, size_t x);
+void PCU_Min_Ints_2(pcu_t* pcu, int* p, size_t n);
+int PCU_Min_Int_2(pcu_t* pcu, int x);
+void PCU_Max_Ints_2(pcu_t* pcu, int* p, size_t n);
+int PCU_Max_Int_2(pcu_t* pcu, int x);
+void PCU_Max_Longs_2(pcu_t* pcu, long* p, size_t n);
+long PCU_Max_Long_2(pcu_t* pcu, long x);
+int PCU_Or_2(pcu_t* pcu, int c);
+int PCU_And_2(pcu_t* pcu, int c);
+
+/*process-level self/peers (mpi wrappers)*/
+int PCU_Proc_Self_2(pcu_t* pcu);
+int PCU_Proc_Peers_2(pcu_t* pcu);
+
+/*IPComMan replacement API*/
+int PCU_Comm_Write_2(pcu_t* pcu, int to_rank, const void* data, size_t size);
+bool PCU_Comm_Read_2(pcu_t* pcu, int* from_rank, void** data, size_t* size);
+
+/*Debug file I/O API*/
+void PCU_Debug_Open_2(pcu_t* pcu);
+void PCU_Debug_Printv_2(pcu_t* pcu, const char* format, va_list args);
+#ifdef __GNUC__
+void PCU_Debug_Print_2(pcu_t* pcu, const char* format, ...)
+  __attribute__((format(printf,2,3)));
+#else
+void PCU_Debug_Print(pcu_t* pcu, const char* format, ...);
+#endif
+
+/*lesser-used APIs*/
+bool PCU_Comm_Initialized_2(pcu_t* pcu);
+int PCU_Comm_Packed_2(pcu_t* pcu, int to_rank, size_t* size);
+int PCU_Comm_From_2(pcu_t* pcu, int* from_rank);
+int PCU_Comm_Received_2(pcu_t* pcu, size_t* size);
+void* PCU_Comm_Extract_2(pcu_t* pcu, size_t size);
+int PCU_Comm_Rank_2(pcu_t* pcu, int* rank);
+int PCU_Comm_Size_2(pcu_t* pcu, int* size);
+
+int PCU_Comm_Start_2(pcu_t* pcu);
+
+/*special MPI_Comm replacement API*/
+void PCU_Switch_Comm_2(pcu_t* pcu, MPI_Comm new_comm);
+MPI_Comm PCU_Get_Comm_2(pcu_t* pcu);
+
+/*stack trace helpers using GNU/Linux*/
+void PCU_Protect_2(pcu_t* pcu);
+
+/*MPI_Wtime_() equivalent*/
+double PCU_Time_2(pcu_t* pcu);
+
+/*Memory usage*/
+double PCU_GetMem_2(pcu_t* pcu);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif

--- a/pcu/pcu.c
+++ b/pcu/pcu.c
@@ -751,7 +751,7 @@ void PCU_Switch_Comm(MPI_Comm new_comm)
   MPI_Comm_compare(new_comm, global_mpi->original_comm, &result);
   if (result != MPI_IDENT) {
     pcu_mpi_finalize(&global_mpi);
-    pcu_mpi_init(new_comm);
+    global_mpi = pcu_mpi_init(new_comm);
   }
 }
 

--- a/pcu/pcu.c
+++ b/pcu/pcu.c
@@ -53,7 +53,7 @@ static pcu_t global_pcu = {.state=pcu_state_uninit};
  */
 int PCU_Comm_Init(void)
 {
-  PCU_Comm_Init_2(&global_pcu);
+  return PCU_Comm_Init_2(&global_pcu);
 }
 
 /** \brief Frees all PCU library structures.
@@ -504,7 +504,7 @@ void PCU_Switch_Comm(MPI_Comm new_comm)
  */
 MPI_Comm PCU_Get_Comm(void)
 {
-  PCU_Get_Comm_2(&global_pcu);
+  return PCU_Get_Comm_2(&global_pcu);
 }
 
 /** \brief Return the time in seconds since some time in the past

--- a/pcu/pcu2.c
+++ b/pcu/pcu2.c
@@ -774,10 +774,14 @@ MPI_Comm PCU_Get_Comm_2(pcu_t* pcu)
  */
 double PCU_Time_2(pcu_t* pcu)
 {
+  // silence warning
+  (void)pcu;
   return MPI_Wtime();
 }
 
 void PCU_Protect_2(pcu_t* pcu)
 {
+  // silence warning
+  (void)pcu;
   reel_protect();
 }

--- a/pcu/pcu2.c
+++ b/pcu/pcu2.c
@@ -1,0 +1,783 @@
+/****************************************************************************** 
+
+  Copyright 2011 Scientific Computation Research Center, 
+      Rensselaer Polytechnic Institute. All rights reserved.
+  
+  This work is open source software, licensed under the terms of the
+  BSD license as described in the LICENSE file in the top-level directory.
+
+*******************************************************************************/
+/** \file pcu->c
+    \brief The PCU communication interface */
+/** \page pcu PCU
+  PCU (the Parallel Control Utility) is a library for parallel computation
+  based on MPI.
+  PCU provides three things to users:
+    1. A hybrid phased message passing system
+    2. Hybrid collective operations
+
+  Phased message passing is similar to Bulk Synchronous Parallel.
+  All messages are exchanged in a phase, which is a collective operation
+  involving all threads in the parallel program.
+  During a phase, the following events happen in sequence:
+    1. All threads send non-blocking messages to other threads
+    2. All threads receive all messages sent to them during this phase
+  PCU provides termination detection, which is the ability to detect when all
+  messages have been received without prior knowledge of which threads
+  are sending to which.
+
+  The API documentation is here: pcu->c
+*/
+
+#include <string.h>
+#include <stdarg.h>
+#include "PCU2.h"
+#include "pcu_msg.h"
+#include "pcu_order.h"
+#include "noto_malloc.h"
+#include "reel.h"
+#include <sys/types.h> /*required for mode_t for mkdir on some systems*/
+#include <sys/stat.h> /*using POSIX mkdir call for SMB "foo/" path*/
+#include <errno.h> /* for checking the error from mkdir */
+#include <limits.h> /*INT_MAX*/
+#include <stdlib.h> /*abort*/
+
+
+static pcu_msg* get_msg(pcu_t * pcu)
+{
+  return &(pcu->pmsg);
+}
+
+/** \brief Initializes the PCU library.
+  \details This function must be called by all MPI processes before
+  calling any other PCU functions.
+  MPI_Init or MPI_Init_thread should be called before this function.
+ */
+int PCU_Comm_Init_2(pcu_t* pcu)
+{
+  if (pcu->state != pcu_state_uninit)
+    reel_fail("nested calls to Comm_Init");
+  pcu_mpi_init(MPI_COMM_WORLD,&(pcu->mpi));
+  pcu_make_msg(&(pcu->pmsg));
+  pcu->state = pcu_state_init;
+  /* turn ordering on by default, call
+     PCU_Comm_Order(false) after PCU_Comm_Init
+     to disable this */
+  PCU_Comm_Order_2(pcu, true);
+  return PCU_SUCCESS;
+}
+
+/** \brief Frees all PCU library structures.
+  \details This function must be called by all MPI processes after all
+  other calls to PCU, and before calling MPI_Finalize.
+ */
+int PCU_Comm_Free_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Free called before Comm_Init");
+  if (pcu->pmsg.order)
+    pcu_order_free(pcu->pmsg.order);
+  pcu_free_msg(&(pcu->pmsg));
+  pcu_mpi_finalize(&(pcu->mpi));
+  pcu->state = pcu_state_uninit;
+  return PCU_SUCCESS;
+}
+
+/** \brief Returns the communication rank of the calling thread.
+  \details when called from a non-threaded MPI process, this function is
+  equivalent to MPI_Comm_rank(MPI_COMM_WORLD,rank).
+
+  Ranks are consecutive from 0 to \f$pt-1\f$ for a program with
+  \f$p\f$ processes and \f$t\f$ threads per process.
+  Ranks are contiguous within a process, so that the \f$t\f$ threads in process
+  \f$i\f$ are numbered from \f$ti\f$ to \f$ti+t-1\f$.
+ */
+int PCU_Comm_Self_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Self called before Comm_Init");
+  return pcu_mpi_rank(&(pcu->mpi));
+}
+
+/** \brief Returns the number of threads in the program.
+  \details when called from a non-threaded MPI process, this function is
+  equivalent to MPI_Comm_size(MPI_COMM_WORLD,size).
+ */
+int PCU_Comm_Peers_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Peers called before Comm_Init");
+  return pcu_mpi_size(&(pcu->mpi));
+}
+
+/** \brief Begins a PCU communication phase.
+  \details This function must be called by all threads in the MPI job
+  at the beginning of each phase of communication.
+  After calling this function, each thread may call functions like
+  PCU_Comm_Pack or PCU_Comm_Write.
+*/
+void PCU_Comm_Begin_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Begin called before Comm_Init");
+  pcu_msg_start(&(pcu->mpi), get_msg(pcu));
+}
+
+/** \brief Packs data to be sent to \a to_rank.
+  \details This function appends the block of \a size bytes starting
+  at \a data to the buffer being sent to \a to_rank.
+  This function should be called after PCU_Comm_Start and before
+  PCU_Comm_Send.
+ */
+int PCU_Comm_Pack_2(pcu_t* pcu, int to_rank, const void* data, size_t size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Pack called before Comm_Init");
+  if ((to_rank < 0)||(to_rank >= pcu_mpi_size(&(pcu->mpi))))
+    reel_fail("Invalid rank in Comm_Pack");
+  if ( size > (size_t)INT_MAX ) {
+	  fprintf(stderr, "ERROR Attempting to pack a PCU message whose size exceeds INT_MAX... exiting\n");
+	  abort();
+  }
+  memcpy(pcu_msg_pack(get_msg(pcu),to_rank,size),data,size);
+  return PCU_SUCCESS;
+}
+
+/** \brief Sends all buffers for this communication phase.
+  \details This function should be called by all threads in the MPI job
+  after calls to PCU_Comm_Pack or PCU_Comm_Write and before calls
+  to PCU_Comm_Listen or PCU_Comm_Read.
+  All buffers from this thread are sent out and receiving
+  may begin after this call.
+ */
+int PCU_Comm_Send_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Send called before Comm_Init");
+  pcu_msg_send(&(pcu->mpi), get_msg(pcu));
+  return PCU_SUCCESS;
+}
+
+/** \brief Tries to receive a buffer for this communication phase.
+  \details Either this function or PCU_Comm_Read should be called at least
+  once by all threads during the communication phase, after PCU_Comm_Send
+  is called. The result will be false if and only if the communication phase
+  is over and there are no more buffers to receive.
+  Otherwise, a buffer was received.
+  Its contents are retrievable through PCU_Comm_Unpack, and its metadata through
+  PCU_Comm_Sender and PCU_Comm_Received.
+  Users should unpack all data from this buffer before calling this function
+  again, because the previously received buffer is destroyed by the call.
+ */
+bool PCU_Comm_Listen_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Listen called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    return pcu_order_receive(&(pcu->mpi), m->order, m);
+  return pcu_msg_receive(&(pcu->mpi), m);
+}
+
+/** \brief Returns in * \a from_rank the sender of the current received buffer.
+  \details This function should be called after a successful PCU_Comm_Listen.
+ */
+int PCU_Comm_Sender_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Sender called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    return pcu_order_received_from(m->order);
+  return pcu_msg_received_from(m);
+}
+
+/** \brief Returns true if the current received buffer has been unpacked.
+  \details This function should be called after a successful PCU_Comm_Listen.
+ */
+bool PCU_Comm_Unpacked_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Unpacked called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    return pcu_order_unpacked(m->order);
+  return pcu_msg_unpacked(m);
+}
+
+/** \brief Unpacks a block of data from the current received buffer.
+  \details This function should be called after a successful PCU_Comm_Listen.
+  \a data must point to a block of memory of at least \a size bytes, into
+  which the next \a size bytes of the current received buffer will be written.
+  Subsequent calls will begin unpacking where this call left off,
+  so that the entire received buffer can be unpacked by a sequence of calls to
+  this function.
+  Users must ensure that there remain \a size bytes to be unpacked,
+  PCU_Comm_Unpacked can help with this.
+ */
+int PCU_Comm_Unpack_2(pcu_t* pcu, void* data, size_t size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Unpack called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    memcpy(data,pcu_order_unpack(m->order,size),size);
+  else
+    memcpy(data,pcu_msg_unpack(m,size),size);
+  return PCU_SUCCESS;
+}
+
+void PCU_Comm_Order_2(pcu_t* pcu, bool on)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Order called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (on && (!m->order))
+    m->order = pcu_order_new();
+  if ((!on) && m->order) {
+    pcu_order_free(m->order);
+    m->order = NULL;
+  }
+}
+
+/** \brief Blocking barrier over all threads. */
+void PCU_Barrier_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Barrier called before Comm_Init");
+  pcu_barrier(&(pcu->mpi), &(get_msg(pcu)->coll));
+}
+
+/** \brief Performs an Allreduce sum of double arrays.
+  \details This function must be called by all ranks at
+  the same time. \a p must point to an array of \a n doubles.
+  After this call, p[i] will contain the sum of all p[i]'s
+  given by each rank.
+  */
+void PCU_Add_Doubles_2(pcu_t* pcu, double* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Add_Doubles called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_doubles,p,n*sizeof(double));
+}
+
+double PCU_Add_Double_2(pcu_t* pcu, double x)
+{
+  double a[1];
+  a[0] = x;
+  PCU_Add_Doubles_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce minimum of double arrays.
+  */
+void PCU_Min_Doubles_2(pcu_t* pcu, double* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Min_Doubles called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_min_doubles,p,n*sizeof(double));
+}
+
+double PCU_Min_Double_2(pcu_t* pcu, double x)
+{
+  double a[1];
+  a[0] = x;
+  PCU_Min_Doubles_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce maximum of double arrays.
+  */
+void PCU_Max_Doubles_2(pcu_t* pcu, double* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Max_Doubles called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_max_doubles,p,n*sizeof(double));
+}
+
+double PCU_Max_Double_2(pcu_t* pcu, double x)
+{
+  double a[1];
+  a[0] = x;
+  PCU_Max_Doubles_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce sum of integers
+  */
+void PCU_Add_Ints_2(pcu_t* pcu, int* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Add_Ints called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_ints,p,n*sizeof(int));
+}
+
+int PCU_Add_Int_2(pcu_t* pcu, int x)
+{
+  int a[1];
+  a[0] = x;
+  PCU_Add_Ints_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce sum of long integers
+  */
+void PCU_Add_Longs_2(pcu_t* pcu, long* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Add_Longs called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_longs,p,n*sizeof(long));
+}
+
+long PCU_Add_Long_2(pcu_t* pcu, long x)
+{
+  long a[1];
+  a[0] = x;
+  PCU_Add_Longs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce sum of size_t unsigned integers
+  */
+void PCU_Add_SizeTs_2(pcu_t* pcu, size_t* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Add_SizeTs called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_sizets,p,n*sizeof(size_t));
+}
+
+size_t PCU_Add_SizeT_2(pcu_t* pcu, size_t x)
+{
+  size_t a[1];
+  a[0] = x;
+  PCU_Add_SizeTs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce minimum of size_t unsigned integers
+  */
+void PCU_Min_SizeTs_2(pcu_t* pcu, size_t* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Min_SizeTs called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_min_sizets,p,n*sizeof(size_t));
+}
+
+size_t PCU_Min_SizeT_2(pcu_t* pcu, size_t x)
+{
+  size_t a[1];
+  a[0] = x;
+  PCU_Min_SizeTs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce maximum of size_t unsigned integers
+  */
+void PCU_Max_SizeTs_2(pcu_t* pcu, size_t* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Max_SizeTs called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_max_sizets,p,n*sizeof(size_t));
+}
+
+size_t PCU_Max_SizeT_2(pcu_t* pcu, size_t x)
+{
+  size_t a[1];
+  a[0] = x;
+  PCU_Max_SizeTs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an exclusive prefix sum of integer arrays.
+  \details This function must be called by all ranks at
+  the same time. \a p must point to an array of \a n integers.
+  After this call, p[i] will contain the sum of all p[i]'s
+  given by ranks lower than the calling rank.
+  */
+void PCU_Exscan_Ints_2(pcu_t* pcu, int* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Exscan_Ints called before Comm_Init");
+  int* originals;
+  NOTO_MALLOC(originals,n);
+  for (size_t i=0; i < n; ++i)
+    originals[i] = p[i];
+  pcu_scan(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_ints,p,n*sizeof(int));
+  //convert inclusive scan to exclusive
+  for (size_t i=0; i < n; ++i)
+    p[i] -= originals[i];
+  noto_free(originals);
+}
+
+int PCU_Exscan_Int_2(pcu_t* pcu, int x)
+{
+  int a[1];
+  a[0] = x;
+  PCU_Exscan_Ints_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief See PCU_Exscan_Ints */
+void PCU_Exscan_Longs_2(pcu_t* pcu, long* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Exscan_Longs called before Comm_Init");
+  long* originals;
+  NOTO_MALLOC(originals,n);
+  for (size_t i=0; i < n; ++i)
+    originals[i] = p[i];
+  pcu_scan(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_add_longs,p,n*sizeof(long));
+  //convert inclusive scan to exclusive
+  for (size_t i=0; i < n; ++i)
+    p[i] -= originals[i];
+  noto_free(originals);
+}
+
+long PCU_Exscan_Long_2(pcu_t* pcu, long x)
+{
+  long a[1];
+  a[0] = x;
+  PCU_Exscan_Longs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce minimum of int arrays.
+  */
+void PCU_Min_Ints_2(pcu_t* pcu, int* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Min_Ints called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_min_ints,p,n*sizeof(int));
+}
+
+int PCU_Min_Int_2(pcu_t* pcu, int x)
+{
+  int a[1];
+  a[0] = x;
+  PCU_Min_Ints_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs an Allreduce maximum of int arrays.
+  */
+void PCU_Max_Ints_2(pcu_t* pcu, int* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Max_Ints called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_max_ints,p,n*sizeof(int));
+}
+
+int PCU_Max_Int_2(pcu_t* pcu, int x)
+{
+  int a[1];
+  a[0] = x;
+  PCU_Max_Ints_2(pcu, a, 1);
+  return a[0];
+}
+/** \brief Performs an Allreduce maximum of long arrays.
+  */
+void PCU_Max_Longs_2(pcu_t* pcu, long* p, size_t n)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Max_Longs called before Comm_Init");
+  pcu_allreduce(&(pcu->mpi), &(get_msg(pcu)->coll),pcu_max_longs,p,n*sizeof(long));
+}
+
+long PCU_Max_Long_2(pcu_t* pcu, long x)
+{
+  long a[1];
+  a[0] = x;
+  PCU_Max_Longs_2(pcu, a, 1);
+  return a[0];
+}
+
+/** \brief Performs a parallel logical OR reduction
+  */
+int PCU_Or_2(pcu_t* pcu, int c)
+{
+  return PCU_Max_Int_2(pcu, c);
+}
+
+/** \brief Performs a parallel logical AND reduction
+  */
+int PCU_And_2(pcu_t* pcu, int c)
+{
+  return PCU_Min_Int_2(pcu, c);
+}
+
+/** \brief Returns the unique rank of the calling process.
+ */
+int PCU_Proc_Self_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Proc_Self called before Comm_Init");
+  return pcu_mpi_rank(&(pcu->mpi));
+}
+
+/** \brief Returns the number of processes.
+ */
+int PCU_Proc_Peers_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Proc_Peers called before Comm_Init");
+  return pcu_mpi_size(&(pcu->mpi));
+}
+
+/** \brief Similar to PCU_Comm_Self, returns the rank as an argument.
+ */
+int PCU_Comm_Rank_2(pcu_t* pcu, int* rank)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Rank called before Comm_Init");
+  *rank = pcu_mpi_rank(&(pcu->mpi));
+  return PCU_SUCCESS;
+}
+
+/** \brief Similar to PCU_Comm_Peers, returns the size as an argument. */
+int PCU_Comm_Size_2(pcu_t* pcu, int* size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Size called before Comm_Init");
+  *size = pcu_mpi_size(&(pcu->mpi));
+  return PCU_SUCCESS;
+}
+
+/** \brief Returns true iff PCU has been initialized */
+bool PCU_Comm_Initialized_2(pcu_t* pcu)
+{
+  return pcu->state == pcu_state_init;
+}
+
+/** \brief Deprecated, see PCU_Comm_Begin.
+ */
+int PCU_Comm_Start_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Start called before Comm_Init");
+  pcu_msg_start(&(pcu->mpi),get_msg(pcu));
+  return PCU_SUCCESS;
+}
+
+/** \brief Returns in * \a size the number of bytes being sent to \a to_rank.
+  \details Returns the size of the buffer being sent to \a to_rank.
+  This function should be called after PCU_Comm_Start and before
+  PCU_Comm_Send.
+ */
+int PCU_Comm_Packed_2(pcu_t* pcu, int to_rank, size_t* size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Packed called before Comm_Init");
+  if ((to_rank < 0)||(to_rank >= pcu_mpi_size(&(pcu->mpi))))
+    reel_fail("Invalid rank in Comm_Packed");
+  *size = pcu_msg_packed(get_msg(pcu),to_rank);
+  return PCU_SUCCESS;
+}
+
+/** \brief Packs a message to be sent to \a to_rank.
+  \details This function packs a message into the buffer being sent
+  to \a to_rank.
+  Messages packed by this function can be received using the function
+  PCU_Comm_Read.
+  This function should be called after PCU_Comm_Start and before
+  PCU_Comm_Send.
+  If this function is used, PCU_Comm_Pack should not be used.
+ */
+int PCU_Comm_Write_2(pcu_t* pcu, int to_rank, const void* data, size_t size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Write called before Comm_Init");
+  if ((to_rank < 0)||(to_rank >= pcu_mpi_size(&(pcu->mpi))))
+    reel_fail("Invalid rank in Comm_Write");
+  pcu_msg* msg = get_msg(pcu);
+  PCU_MSG_PACK(msg,to_rank,size);
+  memcpy(pcu_msg_pack(msg,to_rank,size),data,size);
+  return PCU_SUCCESS;
+}
+
+/** \brief Convenience wrapper over Listen and Unpacked */
+bool PCU_Comm_Receive_2(pcu_t* pcu)
+{
+  while (PCU_Comm_Unpacked_2(pcu))
+    if (!PCU_Comm_Listen_2(pcu))
+      return false;
+  return true;
+}
+
+/** \brief Receives a message for this communication phase.
+  \details This function tries to receive a message packed by
+  PCU_Comm_Write.
+  If a the communication phase is over and there are no more
+  messages to receive, this function returns false.
+  Otherwise, * \a from_rank will be the rank which sent the message,
+ * \a data will point to the start of the message data, and
+ * \a size will be the number of bytes of message data.
+ If this function is used, PCU_Comm_Receive should not be used.
+ Note that the address * \a data points into a PCU buffer, so
+ it is strongly recommended that this data be read and not modified.
+ */
+bool PCU_Comm_Read_2(pcu_t* pcu, int* from_rank, void** data, size_t* size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Read called before Comm_Init");
+  if (!PCU_Comm_Receive_2(pcu))
+    return false;
+  *from_rank = PCU_Comm_Sender_2(pcu);
+  PCU_Comm_Unpack_2(pcu, size, sizeof(*size));
+  *data = PCU_Comm_Extract_2(pcu, *size);
+  return true;
+}
+
+static void safe_mkdir(const char* path, mode_t mode)
+{
+  int err;
+  errno = 0;
+  err = mkdir(path, mode);
+  if (err != 0 && errno != EEXIST)
+    reel_fail("PCU: could not create directory \"%s\"\n", path);
+}
+
+static void append(char* s, size_t size, const char* format, ...)
+{
+  int len = strlen(s);
+  va_list ap;
+  va_start(ap, format);
+  vsnprintf(s + len, size - len, format, ap);
+  va_end(ap);
+}
+
+
+void PCU_Debug_Open_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Debug_Open called before Comm_Init");
+
+  const int fanout = 2048;
+  const int bufsize = 1024;
+  char* path = noto_malloc(bufsize);
+  path[0] = '\0';
+  if (PCU_Comm_Peers_2(pcu) > fanout) {
+    mode_t const dir_perm = S_IRWXU|S_IRGRP|S_IXGRP|S_IROTH|S_IXOTH;
+    strcpy(path, "debug/");
+    safe_mkdir(path, dir_perm);
+    int self = PCU_Comm_Self_2(pcu);
+    append(path, bufsize, "%d/", self / fanout);
+    if (self % fanout == 0)
+      safe_mkdir(path, dir_perm);
+    PCU_Barrier_2(pcu);
+  }
+
+  append(path,bufsize, "%s", "debug");
+  pcu_msg* msg = get_msg(pcu);
+  if ( ! msg->file)
+    msg->file = pcu_open_parallel(path,"txt");
+  noto_free(path);
+}
+
+void PCU_Debug_Printv_2(pcu_t* pcu, const char* format, va_list ap)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Debug_Print called before Comm_Init");
+  pcu_msg* msg = get_msg(pcu);
+  if ( ! msg->file)
+    return; //Print is a no-op if no file is open
+  vfprintf(msg->file,format,ap);
+  fflush(msg->file);
+}
+/** \brief like fprintf, contents go to debugN.txt */
+void PCU_Debug_Print_2(pcu_t* pcu, const char* format, ...)
+{
+  va_list arglist;
+  va_start(arglist,format);
+  PCU_Debug_Printv_2(pcu, format, arglist);
+  va_end(arglist);
+}
+
+/** \brief Similar to PCU_Comm_Sender, returns the rank as an argument. */
+int PCU_Comm_From_2(pcu_t* pcu, int* from_rank)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_From called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    *from_rank = pcu_order_received_from(m->order);
+  else
+    *from_rank = pcu_msg_received_from(m);
+  return PCU_SUCCESS;
+}
+
+/** \brief Returns in * \a size the bytes in the current received buffer
+  \details This function should be called after a successful PCU_Comm_Receive.
+  The size returned will be the total received size regardless of how
+  much unpacking has been done.
+ */
+int PCU_Comm_Received_2(pcu_t* pcu, size_t* size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Received called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    *size = pcu_order_received_size(m->order);
+  else
+    *size = pcu_msg_received_size(m);
+  return PCU_SUCCESS;
+}
+
+/** \brief Extracts a block of data from the current received buffer.
+  \details This function should be called after a successful PCU_Comm_Receive.
+  The next \a size bytes of the current received buffer are unpacked,
+  and an internal pointer to that data is returned.
+  The returned pointer must not be freed by the user.
+ */
+void* PCU_Comm_Extract_2(pcu_t* pcu, size_t size)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Comm_Extract called before Comm_Init");
+  pcu_msg* m = get_msg(pcu);
+  if (m->order)
+    return pcu_order_unpack(m->order,size);
+  return pcu_msg_unpack(m,size);
+}
+
+/** \brief Reinitializes PCU with a new MPI communicator.
+ \details All of PCU's logic is based off two duplicates
+ of this communicator, so you can safely get PCU to act
+ on sub-groups of processes using this function.
+ This call should be collective over all processes
+ in the previous communicator. This is a very heavy weight function
+ and should be used sparingly.
+ */
+void PCU_Switch_Comm_2(pcu_t* pcu, MPI_Comm new_comm)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Switch_Comm called before Comm_Init");
+  int result;
+  MPI_Comm_compare(new_comm, pcu->mpi.original_comm, &result);
+  if (result != MPI_IDENT) {
+    pcu_mpi_finalize(&(pcu->mpi));
+    pcu_mpi_init(new_comm,&(pcu->mpi));
+  }
+}
+
+/** \brief Return the current MPI communicator
+  \details Returns the communicator given to the
+  most recent PCU_Switch_Comm call, or MPI_COMM_WORLD
+  otherwise.
+ */
+MPI_Comm PCU_Get_Comm_2(pcu_t* pcu)
+{
+  if (pcu->state == pcu_state_uninit)
+    reel_fail("Get_Comm called before Comm_Init");
+  return pcu->mpi.original_comm;
+}
+
+/** \brief Return the time in seconds since some time in the past
+ */
+double PCU_Time_2(pcu_t* pcu)
+{
+  return MPI_Wtime();
+}
+
+void PCU_Protect_2(pcu_t* pcu)
+{
+  reel_protect();
+}

--- a/pcu/pcu_coll.c
+++ b/pcu/pcu_coll.c
@@ -223,7 +223,7 @@ bool pcu_progress_coll(pcu_mpi_t* mpi, pcu_coll* c)
    then odd multiples of 2 into even ones, etc...
    until rank 0 has all inputs merged */
 
-static int reduce_begin_bit(pcu_mpi_t*)
+static int reduce_begin_bit(pcu_mpi_t* mpi)
 {
   return 1;
 }
@@ -250,7 +250,7 @@ static int reduce_action(pcu_mpi_t* mpi, int bit)
   return pcu_coll_recv;
 }
 
-static int reduce_shift(pcu_mpi_t*, int bit)
+static int reduce_shift(pcu_mpi_t* mpi, int bit)
 {
   return bit << 1;
 }
@@ -278,7 +278,7 @@ static int bcast_begin_bit(pcu_mpi_t* mpi)
   return bit;
 }
 
-static bool bcast_end_bit(pcu_mpi_t *, int bit)
+static bool bcast_end_bit(pcu_mpi_t * mpi, int bit)
 {
   return bit == 0;
 }
@@ -297,7 +297,7 @@ static int bcast_action(pcu_mpi_t* mpi, int bit)
   return pcu_coll_send;
 }
 
-static int bcast_shift(pcu_mpi_t *, int bit)
+static int bcast_shift(pcu_mpi_t * mpi, int bit)
 {
   return bit >> 1;
 }
@@ -318,7 +318,7 @@ static pcu_pattern bcast =
    "Parallel Prefix (Scan) Algorithms for MPI".
 */
 
-static int scan_up_begin_bit(pcu_mpi_t*)
+static int scan_up_begin_bit(pcu_mpi_t* mpi)
 {
   return 1;
 }
@@ -371,7 +371,7 @@ static int scan_up_peer(pcu_mpi_t* mpi, int bit)
   return -1;
 }
 
-static int scan_up_shift(pcu_mpi_t*, int bit)
+static int scan_up_shift(pcu_mpi_t* mpi, int bit)
 {
   return bit << 1;
 }
@@ -390,7 +390,7 @@ static int scan_down_begin_bit(pcu_mpi_t* mpi)
   return 1 << floor_log2(pcu_mpi_size(mpi));
 }
 
-static bool scan_down_end_bit(pcu_mpi_t*, int bit)
+static bool scan_down_end_bit(pcu_mpi_t* mpi, int bit)
 {
   return bit == 1;
 }
@@ -440,7 +440,7 @@ static int scan_down_peer(pcu_mpi_t * mpi, int bit)
   return -1;
 }
 
-static int scan_down_shift(pcu_mpi_t*, int bit)
+static int scan_down_shift(pcu_mpi_t* mpi, int bit)
 {
   return bit >> 1;
 }

--- a/pcu/pcu_coll.c
+++ b/pcu/pcu_coll.c
@@ -170,6 +170,8 @@ static bool end_coll_step(pcu_mpi_t* mpi, pcu_coll* c)
 
 void pcu_make_coll(pcu_mpi_t* mpi, pcu_coll* c, pcu_pattern* p, pcu_merge* m)
 {
+  // silence warning
+  (void)mpi;
   c->pattern = p;
   c->merge = m;
 }
@@ -225,6 +227,8 @@ bool pcu_progress_coll(pcu_mpi_t* mpi, pcu_coll* c)
 
 static int reduce_begin_bit(pcu_mpi_t* mpi)
 {
+  // silence warning
+  (void)mpi;
   return 1;
 }
 
@@ -252,6 +256,8 @@ static int reduce_action(pcu_mpi_t* mpi, int bit)
 
 static int reduce_shift(pcu_mpi_t* mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit << 1;
 }
 
@@ -280,6 +286,8 @@ static int bcast_begin_bit(pcu_mpi_t* mpi)
 
 static bool bcast_end_bit(pcu_mpi_t * mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit == 0;
 }
 
@@ -299,6 +307,8 @@ static int bcast_action(pcu_mpi_t* mpi, int bit)
 
 static int bcast_shift(pcu_mpi_t * mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit >> 1;
 }
 
@@ -320,6 +330,8 @@ static pcu_pattern bcast =
 
 static int scan_up_begin_bit(pcu_mpi_t* mpi)
 {
+  // silence warning
+  (void)mpi;
   return 1;
 }
 
@@ -373,6 +385,8 @@ static int scan_up_peer(pcu_mpi_t* mpi, int bit)
 
 static int scan_up_shift(pcu_mpi_t* mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit << 1;
 }
 
@@ -392,6 +406,8 @@ static int scan_down_begin_bit(pcu_mpi_t* mpi)
 
 static bool scan_down_end_bit(pcu_mpi_t* mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit == 1;
 }
 
@@ -442,6 +458,8 @@ static int scan_down_peer(pcu_mpi_t * mpi, int bit)
 
 static int scan_down_shift(pcu_mpi_t* mpi, int bit)
 {
+  // silence warning
+  (void)mpi;
   return bit >> 1;
 }
 
@@ -507,6 +525,8 @@ bool pcu_barrier_done(pcu_mpi_t* mpi, pcu_coll* c)
 
 void pcu_barrier(pcu_mpi_t* mpi, pcu_coll* c)
 {
+  // silence warning
+  (void)mpi;
   pcu_begin_barrier(mpi, c);
   while( ! pcu_barrier_done(mpi, c));
 }

--- a/pcu/pcu_coll.c
+++ b/pcu/pcu_coll.c
@@ -8,7 +8,6 @@
 
 *******************************************************************************/
 #include "pcu_coll.h"
-#include "pcu_pmpi.h"
 #include "reel.h"
 #include <string.h>
 
@@ -135,31 +134,31 @@ void pcu_add_longs(void* local, void* incoming, size_t size)
 
 /* initiates non-blocking calls for this
    communication step */
-static void begin_coll_step(pcu_coll* c)
+static void begin_coll_step(pcu_mpi_t* mpi, pcu_coll* c)
 {
-  int action = c->pattern->action(c->bit);
+  int action = c->pattern->action(mpi, c->bit);
   if (action == pcu_coll_idle)
     return;
-  c->message.peer = c->pattern->peer(c->bit);
+  c->message.peer = c->pattern->peer(mpi, c->bit);
   if (action == pcu_coll_send)
-    pcu_mpi_send(&(c->message),pcu_coll_comm);
+    pcu_mpi_send(mpi, &(c->message),mpi->coll_comm);
 }
 
 /* tries to complete this communication step.
    Returns false if communication is not done,
    otherwise wraps up communication, merges
    if necessary, and returns true */
-static bool end_coll_step(pcu_coll* c)
+static bool end_coll_step(pcu_mpi_t* mpi, pcu_coll* c)
 {
-  int action = c->pattern->action(c->bit);
+  int action = c->pattern->action(mpi, c->bit);
   if (action == pcu_coll_idle)
     return true;
   if (action == pcu_coll_send)
-    return pcu_mpi_done(&(c->message));
+    return pcu_mpi_done(mpi, &(c->message));
   pcu_message incoming;
   pcu_make_message(&incoming);
-  incoming.peer = c->pattern->peer(c->bit);
-  if ( ! pcu_mpi_receive(&incoming,pcu_coll_comm))
+  incoming.peer = c->pattern->peer(mpi, c->bit);
+  if ( ! pcu_mpi_receive(mpi, &incoming,mpi->coll_comm))
     return false;
   if (c->message.buffer.size != incoming.buffer.size)
     reel_fail("PCU unexpected incoming message.\n"
@@ -169,7 +168,7 @@ static bool end_coll_step(pcu_coll* c)
   return true;
 }
 
-void pcu_make_coll(pcu_coll* c, pcu_pattern* p, pcu_merge* m)
+void pcu_make_coll(pcu_mpi_t* mpi, pcu_coll* c, pcu_pattern* p, pcu_merge* m)
 {
   c->pattern = p;
   c->merge = m;
@@ -194,28 +193,28 @@ void pcu_make_coll(pcu_coll* c, pcu_pattern* p, pcu_merge* m)
 /* begins a non-blocking collective.
    The collective operation should be set with pcu_make_coll first.
    data[0..size] is the input/output local data */
-void pcu_begin_coll(pcu_coll* c, void* data, size_t size)
+void pcu_begin_coll(pcu_mpi_t* mpi, pcu_coll* c, void* data, size_t size)
 {
   pcu_set_buffer(&(c->message.buffer),data,size);
-  c->bit = c->pattern->begin_bit();
-  if (c->pattern->end_bit(c->bit))
+  c->bit = c->pattern->begin_bit(mpi);
+  if (c->pattern->end_bit(mpi, c->bit))
     return;
-  begin_coll_step(c);
+  begin_coll_step(mpi, c);
 }
 
 /* makes progress on a collective operation
    started by pcu_begin_coll.
    returns false if its done. */
-bool pcu_progress_coll(pcu_coll* c)
+bool pcu_progress_coll(pcu_mpi_t* mpi, pcu_coll* c)
 {
-  if (c->pattern->end_bit(c->bit))
+  if (c->pattern->end_bit(mpi, c->bit))
     return false;
-  if (end_coll_step(c))
+  if (end_coll_step(mpi, c))
   {
-    c->bit = c->pattern->shift(c->bit);
-    if (c->pattern->end_bit(c->bit))
+    c->bit = c->pattern->shift(mpi, c->bit);
+    if (c->pattern->end_bit(mpi, c->bit))
       return false;
-    begin_coll_step(c);
+    begin_coll_step(mpi, c);
   }
   return true;
 }
@@ -224,34 +223,34 @@ bool pcu_progress_coll(pcu_coll* c)
    then odd multiples of 2 into even ones, etc...
    until rank 0 has all inputs merged */
 
-static int reduce_begin_bit(void)
+static int reduce_begin_bit(pcu_mpi_t*)
 {
   return 1;
 }
 
-static bool reduce_end_bit(int bit)
+static bool reduce_end_bit(pcu_mpi_t* mpi, int bit)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   if (rank==0)
-    return bit >= pcu_mpi_size();
+    return bit >= pcu_mpi_size(mpi);
   return (bit>>1) & rank;
 }
 
-static int reduce_peer(int bit)
+static int reduce_peer(pcu_mpi_t* mpi, int bit)
 {
-  return pcu_mpi_rank() ^ bit;
+  return pcu_mpi_rank(mpi) ^ bit;
 }
 
-static int reduce_action(int bit)
+static int reduce_action(pcu_mpi_t* mpi, int bit)
 {
-  if (reduce_peer(bit) >= pcu_mpi_size())
+  if (reduce_peer(mpi, bit) >= pcu_mpi_size(mpi))
     return pcu_coll_idle;
-  if (bit & pcu_mpi_rank())
+  if (bit & pcu_mpi_rank(mpi))
     return pcu_coll_send;
   return pcu_coll_recv;
 }
 
-static int reduce_shift(int bit)
+static int reduce_shift(pcu_mpi_t*, int bit)
 {
   return bit << 1;
 }
@@ -269,36 +268,36 @@ static pcu_pattern reduce =
    the pattern runs backwards and send/recv
    are flipped. */
 
-static int bcast_begin_bit(void)
+static int bcast_begin_bit(pcu_mpi_t* mpi)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   if (rank == 0)
-    return 1 << ceil_log2(pcu_mpi_size());
+    return 1 << ceil_log2(pcu_mpi_size(mpi));
   int bit = 1;
   while ( ! (bit & rank)) bit <<= 1;
   return bit;
 }
 
-static bool bcast_end_bit(int bit)
+static bool bcast_end_bit(pcu_mpi_t *, int bit)
 {
   return bit == 0;
 }
 
-static int bcast_peer(int bit)
+static int bcast_peer(pcu_mpi_t * mpi, int bit)
 {
-  return pcu_mpi_rank() ^ bit;
+  return pcu_mpi_rank(mpi) ^ bit;
 }
 
-static int bcast_action(int bit)
+static int bcast_action(pcu_mpi_t* mpi, int bit)
 {
-  if (bcast_peer(bit) >= pcu_mpi_size())
+  if (bcast_peer(mpi, bit) >= pcu_mpi_size(mpi))
     return pcu_coll_idle;
-  if (bit & pcu_mpi_rank())
+  if (bit & pcu_mpi_rank(mpi))
     return pcu_coll_recv;
   return pcu_coll_send;
 }
 
-static int bcast_shift(int bit)
+static int bcast_shift(pcu_mpi_t *, int bit)
 {
   return bit >> 1;
 }
@@ -319,14 +318,14 @@ static pcu_pattern bcast =
    "Parallel Prefix (Scan) Algorithms for MPI".
 */
 
-static int scan_up_begin_bit(void)
+static int scan_up_begin_bit(pcu_mpi_t*)
 {
   return 1;
 }
 
-static bool scan_up_end_bit(int bit)
+static bool scan_up_end_bit(pcu_mpi_t* mpi, int bit)
 {
-  return bit == (1 << floor_log2(pcu_mpi_size()));
+  return bit == (1 << floor_log2(pcu_mpi_size(mpi)));
 }
 
 static bool scan_up_could_receive(int rank, int bit)
@@ -345,34 +344,34 @@ static int scan_up_receiver_for(int rank, int bit)
   return rank + bit;
 }
 
-static int scan_up_action(int bit)
+static int scan_up_action(pcu_mpi_t* mpi, int bit)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   if ((scan_up_could_receive(rank,bit))&&
       (0 <= scan_up_sender_for(rank,bit)))
     return pcu_coll_recv;
   int receiver = scan_up_receiver_for(rank,bit);
-  if ((receiver < pcu_mpi_size())&&
+  if ((receiver < pcu_mpi_size(mpi))&&
       (scan_up_could_receive(receiver,bit)))
     return pcu_coll_send;
   return pcu_coll_idle;
 }
 
-static int scan_up_peer(int bit)
+static int scan_up_peer(pcu_mpi_t* mpi, int bit)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   int sender = scan_up_sender_for(rank,bit);
   if ((scan_up_could_receive(rank,bit))&&
       (0 <= sender))
     return sender;
   int receiver = scan_up_receiver_for(rank,bit);
-  if ((receiver < pcu_mpi_size())&&
+  if ((receiver < pcu_mpi_size(mpi))&&
       (scan_up_could_receive(receiver,bit)))
     return receiver;
   return -1;
 }
 
-static int scan_up_shift(int bit)
+static int scan_up_shift(pcu_mpi_t*, int bit)
 {
   return bit << 1;
 }
@@ -386,12 +385,12 @@ static pcu_pattern scan_up =
   .shift = scan_up_shift,
 };
 
-static int scan_down_begin_bit(void)
+static int scan_down_begin_bit(pcu_mpi_t* mpi)
 {
-  return 1 << floor_log2(pcu_mpi_size());
+  return 1 << floor_log2(pcu_mpi_size(mpi));
 }
 
-static bool scan_down_end_bit(int bit)
+static bool scan_down_end_bit(pcu_mpi_t*, int bit)
 {
   return bit == 1;
 }
@@ -412,11 +411,11 @@ static int scan_down_sender_for(int rank, int bit)
   return rank - (bit >> 1);
 }
 
-static int scan_down_action(int bit)
+static int scan_down_action(pcu_mpi_t * mpi, int bit)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   if ((scan_down_could_send(rank,bit))&&
-      (scan_down_receiver_for(rank,bit) < pcu_mpi_size()))
+      (scan_down_receiver_for(rank,bit) < pcu_mpi_size(mpi)))
     return pcu_coll_send;
   int sender = scan_down_sender_for(rank,bit);
   if ((0 <= sender)&&
@@ -425,13 +424,13 @@ static int scan_down_action(int bit)
   return pcu_coll_idle;
 }
 
-static int scan_down_peer(int bit)
+static int scan_down_peer(pcu_mpi_t * mpi, int bit)
 {
-  int rank = pcu_mpi_rank();
+  int rank = pcu_mpi_rank(mpi);
   if (scan_down_could_send(rank,bit))
   {
     int receiver = scan_down_receiver_for(rank,bit);
-    if (receiver < pcu_mpi_size())
+    if (receiver < pcu_mpi_size(mpi))
       return receiver;
   }
   int sender = scan_down_sender_for(rank,bit);
@@ -441,7 +440,7 @@ static int scan_down_peer(int bit)
   return -1;
 }
 
-static int scan_down_shift(int bit)
+static int scan_down_shift(pcu_mpi_t*, int bit)
 {
   return bit >> 1;
 }
@@ -455,59 +454,59 @@ static pcu_pattern scan_down =
   .shift = scan_down_shift,
 };
 
-void pcu_reduce(pcu_coll* c, pcu_merge* m, void* data, size_t size)
+void pcu_reduce(pcu_mpi_t* mpi, pcu_coll* c, pcu_merge* m, void* data, size_t size)
 {
-  pcu_make_coll(c,&reduce,m);
-  pcu_begin_coll(c,data,size);
-  while(pcu_progress_coll(c));
+  pcu_make_coll(mpi, c,&reduce,m);
+  pcu_begin_coll(mpi, c,data,size);
+  while(pcu_progress_coll(mpi, c));
 }
 
-void pcu_bcast(pcu_coll* c, void* data, size_t size)
+void pcu_bcast(pcu_mpi_t * mpi, pcu_coll* c, void* data, size_t size)
 {
-  pcu_make_coll(c,&bcast,pcu_merge_assign);
-  pcu_begin_coll(c,data,size);
-  while(pcu_progress_coll(c));
+  pcu_make_coll(mpi, c,&bcast,pcu_merge_assign);
+  pcu_begin_coll(mpi, c,data,size);
+  while(pcu_progress_coll(mpi, c));
 }
 
-void pcu_allreduce(pcu_coll* c, pcu_merge* m, void* data, size_t size)
+void pcu_allreduce(pcu_mpi_t* mpi, pcu_coll* c, pcu_merge* m, void* data, size_t size)
 {
-  pcu_reduce(c,m,data,size);
-  pcu_bcast(c,data,size);
+  pcu_reduce(mpi, c,m,data,size);
+  pcu_bcast(mpi, c,data,size);
 }
 
-void pcu_scan(pcu_coll* c, pcu_merge* m, void* data, size_t size)
+void pcu_scan(pcu_mpi_t* mpi, pcu_coll* c, pcu_merge* m, void* data, size_t size)
 {
-  pcu_make_coll(c,&scan_up,m);
-  pcu_begin_coll(c,data,size);
-  while(pcu_progress_coll(c));
-  pcu_make_coll(c,&scan_down,m);
-  pcu_begin_coll(c,data,size);
-  while(pcu_progress_coll(c));
+  pcu_make_coll(mpi, c,&scan_up,m);
+  pcu_begin_coll(mpi, c,data,size);
+  while(pcu_progress_coll(mpi, c));
+  pcu_make_coll(mpi, c,&scan_down,m);
+  pcu_begin_coll(mpi, c,data,size);
+  while(pcu_progress_coll(mpi, c));
 }
 
 /* a barrier is just an allreduce of nothing in particular */
-void pcu_begin_barrier(pcu_coll* c)
+void pcu_begin_barrier(pcu_mpi_t* mpi, pcu_coll* c)
 {
-  pcu_make_coll(c,&reduce,pcu_merge_assign);
-  pcu_begin_coll(c,NULL,0);
+  pcu_make_coll(mpi, c,&reduce,pcu_merge_assign);
+  pcu_begin_coll(mpi, c,NULL,0);
 }
 
-bool pcu_barrier_done(pcu_coll* c)
+bool pcu_barrier_done(pcu_mpi_t* mpi, pcu_coll* c)
 {
   if (c->pattern == &reduce)
-    if ( ! pcu_progress_coll(c))
+    if ( ! pcu_progress_coll(mpi, c))
     {
-      pcu_make_coll(c,&bcast,pcu_merge_assign);
-      pcu_begin_coll(c,c->message.buffer.start,c->message.buffer.size);
+      pcu_make_coll(mpi, c,&bcast,pcu_merge_assign);
+      pcu_begin_coll(mpi, c,c->message.buffer.start,c->message.buffer.size);
     }
   if (c->pattern == &bcast)
-    if ( ! pcu_progress_coll(c))
+    if ( ! pcu_progress_coll(mpi,c))
       return true;
   return false;
 }
 
-void pcu_barrier(pcu_coll* c)
+void pcu_barrier(pcu_mpi_t* mpi, pcu_coll* c)
 {
-  pcu_begin_barrier(c);
-  while( ! pcu_barrier_done(c));
+  pcu_begin_barrier(mpi, c);
+  while( ! pcu_barrier_done(mpi, c));
 }

--- a/pcu/pcu_coll.h
+++ b/pcu/pcu_coll.h
@@ -57,11 +57,11 @@ enum
  */
 typedef struct
 {
-  int (*begin_bit)(void); //initialize state bit
-  bool (*end_bit)(int bit); //return true if bit is one past the last
-  int (*action)(int bit); //return action enum for this step
-  int (*peer)(int bit); //return the peer to communicate with
-  int (*shift)(int bit); //shift the bit up or down
+  int (*begin_bit)(pcu_mpi_t*); //initialize state bit
+  bool (*end_bit)(pcu_mpi_t*, int bit); //return true if bit is one past the last
+  int (*action)(pcu_mpi_t*, int bit); //return action enum for this step
+  int (*peer)(pcu_mpi_t*, int bit); //return the peer to communicate with
+  int (*shift)(pcu_mpi_t*, int bit); //shift the bit up or down
 } pcu_pattern;
 
 /* The pcu_coll object stores the state of a non-blocking
@@ -74,18 +74,18 @@ typedef struct
   int bit; //pattern's state bit
 } pcu_coll;
 
-void pcu_make_coll(pcu_coll* c, pcu_pattern* p, pcu_merge* m);
-void pcu_begin_coll(pcu_coll* c, void* data, size_t size);
+void pcu_make_coll(pcu_mpi_t *, pcu_coll* c, pcu_pattern* p, pcu_merge* m);
+void pcu_begin_coll(pcu_mpi_t *, pcu_coll* c, void* data, size_t size);
 //returns false when done
-bool pcu_progress_coll(pcu_coll* c);
+bool pcu_progress_coll(pcu_mpi_t* mpi, pcu_coll* c);
 
-void pcu_reduce(pcu_coll* c, pcu_merge* m, void* data, size_t size);
-void pcu_bcast(pcu_coll* c, void* data, size_t size);
-void pcu_allreduce(pcu_coll* c, pcu_merge* m, void* data, size_t size);
-void pcu_scan(pcu_coll* c, pcu_merge* m, void* data, size_t size);
+void pcu_reduce(pcu_mpi_t*, pcu_coll* c, pcu_merge* m, void* data, size_t size);
+void pcu_bcast(pcu_mpi_t*, pcu_coll* c, void* data, size_t size);
+void pcu_allreduce(pcu_mpi_t*, pcu_coll* c, pcu_merge* m, void* data, size_t size);
+void pcu_scan(pcu_mpi_t*, pcu_coll* c, pcu_merge* m, void* data, size_t size);
 
-void pcu_begin_barrier(pcu_coll* c);
-bool pcu_barrier_done(pcu_coll* c);
-void pcu_barrier(pcu_coll* c);
+void pcu_begin_barrier(pcu_mpi_t*,pcu_coll* c);
+bool pcu_barrier_done(pcu_mpi_t*, pcu_coll* c);
+void pcu_barrier(pcu_mpi_t*, pcu_coll* c);
 
 #endif //PCU_COLL_H

--- a/pcu/pcu_io.c
+++ b/pcu/pcu_io.c
@@ -8,16 +8,16 @@
 
 *******************************************************************************/
 #include "pcu_io.h"
-#include "noto_malloc.h"
-#include "reel.h"
-#include "pcu_mpi.h"
 #include "PCU.h"
-#include <stdint.h>
-#include <string.h>
-#include <stdlib.h>
+#include "noto_malloc.h"
+#include "pcu_buffer.h"
 #include "pcu_util.h"
-#include <sys/types.h>
+#include "reel.h"
 #include <limits.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
 
 #ifdef PCU_BZIP
 #include <bzlib.h>
@@ -361,7 +361,8 @@ FILE* pcu_open_parallel(const char* prefix, const char* ext)
   static const size_t max_rank_chars = 10;
   size_t path_size = strlen(prefix) + max_rank_chars + strlen(ext) + 1;
   char* path = noto_malloc(path_size);
-  int rank = pcu_mpi_rank();
+  int rank;
+  PCU_Comm_Rank(&rank);
   snprintf(path,path_size,"%s%d.%s",prefix,rank,ext);
   FILE* file = fopen(path, "w");
   noto_free(path);

--- a/pcu/pcu_mpi.c
+++ b/pcu/pcu_mpi.c
@@ -61,9 +61,9 @@ bool pcu_mpi_receive(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
     check_rank(self, m->peer);
   return pcu_pmpi_receive(self, m, comm);
 }
-pcu_mpi_t* pcu_mpi_init(MPI_Comm comm) {
-  return pcu_pmpi_init(comm);
+void pcu_mpi_init(MPI_Comm comm, pcu_mpi_t* mpi) {
+  pcu_pmpi_init(comm, mpi);
 }
-void pcu_mpi_finalize(pcu_mpi_t** mpi) {
+void pcu_mpi_finalize(pcu_mpi_t* mpi) {
   pcu_pmpi_finalize(mpi);
 }

--- a/pcu/pcu_mpi.c
+++ b/pcu/pcu_mpi.c
@@ -9,8 +9,7 @@
 *******************************************************************************/
 #include "pcu_mpi.h"
 #include "pcu_util.h"
-
-static pcu_mpi* global_mpi;
+#include "pcu_pmpi.h"
 
 void pcu_make_message(pcu_message* m)
 {
@@ -22,47 +21,49 @@ void pcu_free_message(pcu_message* m)
   pcu_free_buffer(&(m->buffer));
 }
 
-void pcu_set_mpi(pcu_mpi* m)
+int pcu_mpi_size(pcu_mpi_t* self)
 {
-  global_mpi = m;
+  return pcu_pmpi_size(self);
 }
 
-pcu_mpi* pcu_get_mpi(void)
+int pcu_mpi_rank(pcu_mpi_t* self)
 {
-  return global_mpi;
+  return pcu_pmpi_rank(self);
 }
 
-int pcu_mpi_size(void)
-{
-  return global_mpi->size();
-}
-
-int pcu_mpi_rank(void)
-{
-  return global_mpi->rank();
-}
-
-static void check_rank(int rank)
+static void check_rank(pcu_mpi_t* self, int rank)
 {
   (void)rank;
   PCU_ALWAYS_ASSERT(0 <= rank);
-  PCU_ALWAYS_ASSERT(rank < pcu_mpi_size());
+  PCU_ALWAYS_ASSERT(rank < pcu_mpi_size(self));
 }
 
-void pcu_mpi_send(pcu_message* m, MPI_Comm comm)
+void pcu_mpi_send(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 {
-  check_rank(m->peer);
-  global_mpi->send(m,comm);
+  check_rank(self, m->peer);
+  // verify that the communicator is one of the user or collective communicators
+  //int user_result, coll_result;
+  //MPI_Comm_compare(comm, self->user_comm, &user_result);
+  //MPI_Comm_compare(comm, self->coll_comm, &coll_result);
+  //PCU_ALWAYS_ASSERT(user_result == MPI_IDENT || coll_result == MPI_IDENT);
+  PCU_ALWAYS_ASSERT(comm == self->user_comm || comm == self->coll_comm);
+  pcu_pmpi_send(self, m, comm);
 }
 
-bool pcu_mpi_done(pcu_message* m)
+bool pcu_mpi_done(pcu_mpi_t* self, pcu_message* m)
 {
-  return global_mpi->done(m);
+  return pcu_pmpi_done(self, m);
 }
 
-bool pcu_mpi_receive(pcu_message* m, MPI_Comm comm)
+bool pcu_mpi_receive(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 {
   if (m->peer != MPI_ANY_SOURCE)
-    check_rank(m->peer);
-  return global_mpi->receive(m,comm);
+    check_rank(self, m->peer);
+  return pcu_pmpi_receive(self, m, comm);
+}
+pcu_mpi_t* pcu_mpi_init(MPI_Comm comm) {
+  return pcu_pmpi_init(comm);
+}
+void pcu_mpi_finalize(pcu_mpi_t** mpi) {
+  pcu_pmpi_finalize(mpi);
 }

--- a/pcu/pcu_mpi.h
+++ b/pcu/pcu_mpi.h
@@ -23,28 +23,14 @@ typedef struct
 void pcu_make_message(pcu_message* m);
 void pcu_free_message(pcu_message* m);
 
-struct pcu_mpi_t_t;
 typedef struct
 {
-  int (*size)(struct pcu_mpi_t_t*);
-  int (*rank)(struct pcu_mpi_t_t*);
-  void (*send)(struct pcu_mpi_t_t *, pcu_message* m, MPI_Comm comm);
-  bool (*done)(struct pcu_mpi_t_t*, pcu_message* m);
-  bool (*receive)(struct pcu_mpi_t_t*, pcu_message* m, MPI_Comm comm);
-  void (*construct)(struct pcu_mpi_t_t*, MPI_Comm comm);
-  void (*destruct)(struct pcu_mpi_t_t*);
-} pcu_mpi_vtable;
-
-struct pcu_mpi_t_t
-{
-  pcu_mpi_vtable const* vtable;
   MPI_Comm original_comm;
   MPI_Comm user_comm;
   MPI_Comm coll_comm;
   int rank;
   int size;
-};
-typedef struct pcu_mpi_t_t pcu_mpi_t;
+} pcu_mpi_t;
 
 int pcu_mpi_size(pcu_mpi_t*);
 int pcu_mpi_rank(pcu_mpi_t*);

--- a/pcu/pcu_mpi.h
+++ b/pcu/pcu_mpi.h
@@ -37,7 +37,7 @@ int pcu_mpi_rank(pcu_mpi_t*);
 void pcu_mpi_send(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
 bool pcu_mpi_done(pcu_mpi_t*, pcu_message* m);
 bool pcu_mpi_receive(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
-pcu_mpi_t* pcu_mpi_init(MPI_Comm comm);
-void pcu_mpi_finalize(pcu_mpi_t**);
+void pcu_mpi_init(MPI_Comm comm, pcu_mpi_t* mpi);
+void pcu_mpi_finalize(pcu_mpi_t* mpi);
 
 #endif

--- a/pcu/pcu_mpi.h
+++ b/pcu/pcu_mpi.h
@@ -23,21 +23,35 @@ typedef struct
 void pcu_make_message(pcu_message* m);
 void pcu_free_message(pcu_message* m);
 
+struct pcu_mpi_t_t;
 typedef struct
 {
-  int (*size)(void);
-  int (*rank)(void);
-  void (*send)(pcu_message* m, MPI_Comm comm);
-  bool (*done)(pcu_message* m);
-  bool (*receive)(pcu_message* m, MPI_Comm comm);
-} pcu_mpi;
+  int (*size)(struct pcu_mpi_t_t*);
+  int (*rank)(struct pcu_mpi_t_t*);
+  void (*send)(struct pcu_mpi_t_t *, pcu_message* m, MPI_Comm comm);
+  bool (*done)(struct pcu_mpi_t_t*, pcu_message* m);
+  bool (*receive)(struct pcu_mpi_t_t*, pcu_message* m, MPI_Comm comm);
+  void (*construct)(struct pcu_mpi_t_t*, MPI_Comm comm);
+  void (*destruct)(struct pcu_mpi_t_t*);
+} pcu_mpi_vtable;
 
-void pcu_set_mpi(pcu_mpi* m);
-pcu_mpi* pcu_get_mpi(void);
-int pcu_mpi_size(void);
-int pcu_mpi_rank(void);
-void pcu_mpi_send(pcu_message* m, MPI_Comm comm);
-bool pcu_mpi_done(pcu_message* m);
-bool pcu_mpi_receive(pcu_message* m, MPI_Comm comm);
+struct pcu_mpi_t_t
+{
+  pcu_mpi_vtable const* vtable;
+  MPI_Comm original_comm;
+  MPI_Comm user_comm;
+  MPI_Comm coll_comm;
+  int rank;
+  int size;
+};
+typedef struct pcu_mpi_t_t pcu_mpi_t;
+
+int pcu_mpi_size(pcu_mpi_t*);
+int pcu_mpi_rank(pcu_mpi_t*);
+void pcu_mpi_send(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
+bool pcu_mpi_done(pcu_mpi_t*, pcu_message* m);
+bool pcu_mpi_receive(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
+pcu_mpi_t* pcu_mpi_init(MPI_Comm comm);
+void pcu_mpi_finalize(pcu_mpi_t**);
 
 #endif

--- a/pcu/pcu_msg.c
+++ b/pcu/pcu_msg.c
@@ -8,7 +8,6 @@
 
 *******************************************************************************/
 #include "pcu_msg.h"
-#include "pcu_pmpi.h"
 #include "noto_malloc.h"
 #include "reel.h"
 #include <string.h>
@@ -87,14 +86,14 @@ static void free_peers(pcu_aa_tree* t)
   pcu_make_aa(t);
 }
 
-void pcu_msg_start(pcu_msg* m)
+void pcu_msg_start(pcu_mpi_t* mpi, pcu_msg* m)
 {
   if (m->state != idle_state)
     reel_fail("PCU_Comm_Begin called at the wrong time");
   /* this barrier ensures no one starts a new superstep
      while others are receiving in the past superstep.
      It is the only blocking call in the pcu_msg system. */
-  pcu_barrier(&(m->coll));
+  pcu_barrier(mpi, &(m->coll));
   m->state = pack_state;
 }
 
@@ -143,49 +142,49 @@ size_t pcu_msg_packed(pcu_msg* m, int id)
   return peer->message.buffer.size;
 }
 
-static void send_peers(pcu_aa_tree t)
+static void send_peers(pcu_mpi_t* mpi, pcu_aa_tree t)
 {
   if (pcu_aa_empty(t))
     return;
   pcu_msg_peer* peer;
   peer = (pcu_msg_peer*)t;
-  pcu_mpi_send(&(peer->message),pcu_user_comm);
-  send_peers(t->left);
-  send_peers(t->right);
+  pcu_mpi_send(mpi, &(peer->message),mpi->user_comm);
+  send_peers(mpi, t->left);
+  send_peers(mpi, t->right);
 }
 
-void pcu_msg_send(pcu_msg* m)
+void pcu_msg_send(pcu_mpi_t* mpi, pcu_msg* m)
 {
   if (m->state != pack_state)
     reel_fail("PCU_Comm_Send called at the wrong time");
-  send_peers(m->peers);
+  send_peers(mpi, m->peers);
   m->state = send_recv_state;
 }
 
-static bool done_sending_peers(pcu_aa_tree t)
+static bool done_sending_peers(pcu_mpi_t* mpi, pcu_aa_tree t)
 {
   if (pcu_aa_empty(t))
     return true;
   pcu_msg_peer* peer;
   peer = (pcu_msg_peer*)t;
-  return pcu_mpi_done(&(peer->message))
-    && done_sending_peers(t->left)
-    && done_sending_peers(t->right);
+  return pcu_mpi_done(mpi, &(peer->message))
+    && done_sending_peers(mpi, t->left)
+    && done_sending_peers(mpi, t->right);
 }
 
-static bool receive_global(pcu_msg* m)
+static bool receive_global(pcu_mpi_t* mpi, pcu_msg* m)
 {
   m->received.peer = MPI_ANY_SOURCE;
-  while ( ! pcu_mpi_receive(&(m->received),pcu_user_comm))
+  while ( ! pcu_mpi_receive(mpi, &(m->received),mpi->user_comm))
   {
     if (m->state == send_recv_state)
-      if (done_sending_peers(m->peers))
+      if (done_sending_peers(mpi, m->peers))
       {
-        pcu_begin_barrier(&(m->coll));
+        pcu_begin_barrier(mpi, &(m->coll));
         m->state = recv_state;
       }
     if (m->state == recv_state)
-      if (pcu_barrier_done(&(m->coll)))
+      if (pcu_barrier_done(mpi, &(m->coll)))
         return false;
   }
   return true;
@@ -197,14 +196,14 @@ static void free_comm(pcu_msg* m)
   pcu_free_message(&(m->received));
 }
 
-bool pcu_msg_receive(pcu_msg* m)
+bool pcu_msg_receive(pcu_mpi_t* mpi, pcu_msg* m)
 {
   if ((m->state != send_recv_state)&&
       (m->state != recv_state))
     reel_fail("PCU_Comm_Receive called at the wrong time");
   if ( ! pcu_msg_unpacked(m))
     reel_fail("PCU_Comm_Receive called before previous message unpacked");
-  if (receive_global(m))
+  if (receive_global(mpi, m))
   {
     pcu_begin_buffer(&(m->received.buffer));
     return true;

--- a/pcu/pcu_msg.h
+++ b/pcu/pcu_msg.h
@@ -45,13 +45,13 @@ struct pcu_msg_struct
 typedef struct pcu_msg_struct pcu_msg;
 
 void pcu_make_msg(pcu_msg* m);
-void pcu_msg_start(pcu_msg* b);
+void pcu_msg_start(pcu_mpi_t*, pcu_msg* b);
 void* pcu_msg_pack(pcu_msg* m, int id, size_t size);
 #define PCU_MSG_PACK(m,id,o) \
 memcpy(pcu_msg_pack(m,id,sizeof(o)),&(o),sizeof(o))
 size_t pcu_msg_packed(pcu_msg* m, int id);
-void pcu_msg_send(pcu_msg* m);
-bool pcu_msg_receive(pcu_msg* m);
+void pcu_msg_send(pcu_mpi_t *mpi, pcu_msg* m);
+bool pcu_msg_receive(pcu_mpi_t* mpi, pcu_msg* m);
 void* pcu_msg_unpack(pcu_msg* m, size_t size);
 #define PCU_MSG_UNPACK(m,o) \
 memcpy(&(o),pcu_msg_unpack(m,sizeof(o)),sizeof(o))

--- a/pcu/pcu_order.c
+++ b/pcu/pcu_order.c
@@ -102,10 +102,10 @@ static void fill(pcu_order o, pcu_aa_tree t)
   fill(o, t->right);
 }
 
-static void prepare(pcu_order o, pcu_msg* t)
+static void prepare(pcu_mpi_t* mpi, pcu_order o, pcu_msg* t)
 {
   struct message* m;
-  while (pcu_msg_receive(t)) {
+  while (pcu_msg_receive(mpi, t)) {
     m = take_message(t);
     pcu_aa_insert(&m->node, &o->tree, message_less);
   }
@@ -117,10 +117,10 @@ static void prepare(pcu_order o, pcu_msg* t)
   o->ready = true;
 }
 
-bool pcu_order_receive(pcu_order o, pcu_msg* m)
+bool pcu_order_receive(pcu_mpi_t* mpi, pcu_order o, pcu_msg* m)
 {
   if (!o->ready)
-    prepare(o, m);
+    prepare(mpi, o, m);
   o->at++;
   if (o->at == o->count) {
     dtor_order(o);

--- a/pcu/pcu_order.h
+++ b/pcu/pcu_order.h
@@ -17,7 +17,7 @@ typedef struct pcu_order_struct* pcu_order;
 
 pcu_order pcu_order_new(void);
 void pcu_order_free(pcu_order o);
-bool pcu_order_receive(pcu_order o, pcu_msg* m);
+bool pcu_order_receive(pcu_mpi_t*, pcu_order o, pcu_msg* m);
 void* pcu_order_unpack(pcu_order o, size_t size);
 bool pcu_order_unpacked(pcu_order o);
 int pcu_order_received_from(pcu_order o);

--- a/pcu/pcu_pmpi.c
+++ b/pcu/pcu_pmpi.c
@@ -13,51 +13,62 @@
 #include <stdlib.h>
 #include <limits.h>
 
-static int global_size;
-static int global_rank;
+void pcu_pmpi_send2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm);
+bool pcu_pmpi_receive2(pcu_mpi_t*, pcu_message* m, int tag, MPI_Comm comm);
+void pcu_pmpi_destruct(pcu_mpi_t* self);
+void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm);
 
-MPI_Comm original_comm;
-MPI_Comm pcu_user_comm;
-MPI_Comm pcu_coll_comm;
-
-pcu_mpi pcu_pmpi =
+static pcu_mpi_vtable pcu_pmpi_vtable =
 { .size = pcu_pmpi_size,
   .rank = pcu_pmpi_rank,
   .send = pcu_pmpi_send,
   .done = pcu_pmpi_done,
-  .receive = pcu_pmpi_receive };
+  .receive = pcu_pmpi_receive,
+  .construct = pcu_pmpi_construct,
+  .destruct = pcu_pmpi_destruct };
 
-void pcu_pmpi_init(MPI_Comm comm)
+pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm)
 {
-  original_comm = comm;
-  MPI_Comm_dup(comm,&pcu_user_comm);
-  MPI_Comm_dup(comm,&pcu_coll_comm);
-  MPI_Comm_size(comm,&global_size);
-  MPI_Comm_rank(comm,&global_rank);
+  pcu_mpi_t* m = (pcu_mpi_t*)malloc(sizeof(pcu_mpi_t));
+  pcu_pmpi_construct(m,comm);
+  return m;
 }
 
-void pcu_pmpi_finalize(void)
+void pcu_pmpi_finalize(pcu_mpi_t** m)
 {
-  MPI_Comm_free(&pcu_user_comm);
-  MPI_Comm_free(&pcu_coll_comm);
+  (*m)->vtable->destruct(*m);
+  free(*m);
+  *m = NULL;
+}
+void pcu_pmpi_destruct(pcu_mpi_t* self) {
+  MPI_Comm_free(&(self->user_comm));
+  MPI_Comm_free(&(self->coll_comm));
+}
+void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm) {
+  self->original_comm = comm;
+  MPI_Comm_dup(comm,&(self->user_comm));
+  MPI_Comm_dup(comm,&(self->coll_comm));
+  MPI_Comm_size(comm,&(self->size));
+  MPI_Comm_rank(comm,&(self->rank));
+  self->vtable = &pcu_pmpi_vtable;
 }
 
-int pcu_pmpi_size(void)
+int pcu_pmpi_size(pcu_mpi_t* self)
 {
-  return global_size;
+  return self->size;
 }
 
-int pcu_pmpi_rank(void)
+int pcu_pmpi_rank(pcu_mpi_t* self)
 {
-  return global_rank;
+  return self->rank;
 }
 
-void pcu_pmpi_send(pcu_message* m, MPI_Comm comm)
+void pcu_pmpi_send(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 {
-  pcu_pmpi_send2(m,0,comm);
+  pcu_pmpi_send2(self, m,0,comm);
 }
 
-void pcu_pmpi_send2(pcu_message* m, int tag, MPI_Comm comm)
+void pcu_pmpi_send2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm)
 {
   if( m->buffer.size > (size_t)INT_MAX ) {
     fprintf(stderr, "ERROR PCU message size exceeds INT_MAX... exiting\n");
@@ -73,19 +84,19 @@ void pcu_pmpi_send2(pcu_message* m, int tag, MPI_Comm comm)
       &(m->request));
 }
 
-bool pcu_pmpi_done(pcu_message* m)
+bool pcu_pmpi_done(pcu_mpi_t* self, pcu_message* m)
 {
   int flag;
   MPI_Test(&(m->request),&flag,MPI_STATUS_IGNORE);
   return flag;
 }
 
-bool pcu_pmpi_receive(pcu_message* m, MPI_Comm comm)
+bool pcu_pmpi_receive(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 {
-  return pcu_pmpi_receive2(m,0,comm);
+  return pcu_pmpi_receive2(self, m,0,comm);
 }
 
-bool pcu_pmpi_receive2(pcu_message* m, int tag, MPI_Comm comm)
+bool pcu_pmpi_receive2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm)
 {
   MPI_Status status;
   int flag;
@@ -106,15 +117,3 @@ bool pcu_pmpi_receive2(pcu_message* m, int tag, MPI_Comm comm)
       MPI_STATUS_IGNORE);
   return true;
 }
-
-void pcu_pmpi_switch(MPI_Comm new_comm)
-{
-  pcu_pmpi_finalize();
-  pcu_pmpi_init(new_comm);
-}
-
-MPI_Comm pcu_pmpi_comm(void)
-{
-  return original_comm;
-}
-

--- a/pcu/pcu_pmpi.c
+++ b/pcu/pcu_pmpi.c
@@ -48,6 +48,8 @@ void pcu_pmpi_send(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 
 void pcu_pmpi_send2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm)
 {
+  // silence warning
+  (void)self;
   if( m->buffer.size > (size_t)INT_MAX ) {
     fprintf(stderr, "ERROR PCU message size exceeds INT_MAX... exiting\n");
     abort();
@@ -64,6 +66,8 @@ void pcu_pmpi_send2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm)
 
 bool pcu_pmpi_done(pcu_mpi_t* self, pcu_message* m)
 {
+  // silence warning
+  (void)self;
   int flag;
   MPI_Test(&(m->request),&flag,MPI_STATUS_IGNORE);
   return flag;
@@ -71,11 +75,15 @@ bool pcu_pmpi_done(pcu_mpi_t* self, pcu_message* m)
 
 bool pcu_pmpi_receive(pcu_mpi_t* self, pcu_message* m, MPI_Comm comm)
 {
+  // silence warning
+  (void)self;
   return pcu_pmpi_receive2(self, m,0,comm);
 }
 
 bool pcu_pmpi_receive2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm)
 {
+  // silence warning
+  (void)self;
   MPI_Status status;
   int flag;
   MPI_Iprobe(m->peer,tag,comm,&flag,&status);

--- a/pcu/pcu_pmpi.c
+++ b/pcu/pcu_pmpi.c
@@ -15,33 +15,20 @@
 
 void pcu_pmpi_send2(pcu_mpi_t* self, pcu_message* m, int tag, MPI_Comm comm);
 bool pcu_pmpi_receive2(pcu_mpi_t*, pcu_message* m, int tag, MPI_Comm comm);
-void pcu_pmpi_destruct(pcu_mpi_t* self);
-void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm);
 
-
-pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm)
+void pcu_pmpi_init(MPI_Comm comm, pcu_mpi_t* self)
 {
-  pcu_mpi_t* m = (pcu_mpi_t*)malloc(sizeof(pcu_mpi_t));
-  pcu_pmpi_construct(m,comm);
-  return m;
-}
-
-void pcu_pmpi_finalize(pcu_mpi_t** m)
-{
-  pcu_pmpi_destruct(*m);
-  free(*m);
-  *m = NULL;
-}
-void pcu_pmpi_destruct(pcu_mpi_t* self) {
-  MPI_Comm_free(&(self->user_comm));
-  MPI_Comm_free(&(self->coll_comm));
-}
-void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm) {
   self->original_comm = comm;
   MPI_Comm_dup(comm,&(self->user_comm));
   MPI_Comm_dup(comm,&(self->coll_comm));
   MPI_Comm_size(comm,&(self->size));
   MPI_Comm_rank(comm,&(self->rank));
+}
+
+void pcu_pmpi_finalize(pcu_mpi_t* self)
+{
+  MPI_Comm_free(&(self->user_comm));
+  MPI_Comm_free(&(self->coll_comm));
 }
 
 int pcu_pmpi_size(pcu_mpi_t* self)

--- a/pcu/pcu_pmpi.c
+++ b/pcu/pcu_pmpi.c
@@ -18,14 +18,6 @@ bool pcu_pmpi_receive2(pcu_mpi_t*, pcu_message* m, int tag, MPI_Comm comm);
 void pcu_pmpi_destruct(pcu_mpi_t* self);
 void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm);
 
-static pcu_mpi_vtable pcu_pmpi_vtable =
-{ .size = pcu_pmpi_size,
-  .rank = pcu_pmpi_rank,
-  .send = pcu_pmpi_send,
-  .done = pcu_pmpi_done,
-  .receive = pcu_pmpi_receive,
-  .construct = pcu_pmpi_construct,
-  .destruct = pcu_pmpi_destruct };
 
 pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm)
 {
@@ -36,7 +28,7 @@ pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm)
 
 void pcu_pmpi_finalize(pcu_mpi_t** m)
 {
-  (*m)->vtable->destruct(*m);
+  pcu_pmpi_destruct(*m);
   free(*m);
   *m = NULL;
 }
@@ -50,7 +42,6 @@ void pcu_pmpi_construct(pcu_mpi_t* self, MPI_Comm comm) {
   MPI_Comm_dup(comm,&(self->coll_comm));
   MPI_Comm_size(comm,&(self->size));
   MPI_Comm_rank(comm,&(self->rank));
-  self->vtable = &pcu_pmpi_vtable;
 }
 
 int pcu_pmpi_size(pcu_mpi_t* self)

--- a/pcu/pcu_pmpi.h
+++ b/pcu/pcu_pmpi.h
@@ -14,8 +14,8 @@
 
 #include <stdbool.h>
 
-pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm);
-void pcu_pmpi_finalize(pcu_mpi_t** m);
+void pcu_pmpi_init(MPI_Comm comm, pcu_mpi_t* mpi);
+void pcu_pmpi_finalize(pcu_mpi_t* m);
 int pcu_pmpi_size(pcu_mpi_t* self);
 int pcu_pmpi_rank(pcu_mpi_t* self);
 void pcu_pmpi_send(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);

--- a/pcu/pcu_pmpi.h
+++ b/pcu/pcu_pmpi.h
@@ -14,22 +14,12 @@
 
 #include <stdbool.h>
 
-void pcu_pmpi_init(MPI_Comm comm);
-void pcu_pmpi_finalize(void);
-int  pcu_pmpi_size(void);
-int  pcu_pmpi_rank(void);
-void pcu_pmpi_send(pcu_message* m, MPI_Comm comm);
-bool pcu_pmpi_receive(pcu_message* m, MPI_Comm comm);
-void pcu_pmpi_send2(pcu_message* m, int tag, MPI_Comm comm);
-bool pcu_pmpi_receive2(pcu_message* m, int tag, MPI_Comm comm);
-bool pcu_pmpi_done(pcu_message* m);
-
-void pcu_pmpi_switch(MPI_Comm new_comm);
-MPI_Comm pcu_pmpi_comm(void);
-
-extern pcu_mpi pcu_pmpi;
-
-extern MPI_Comm pcu_user_comm;
-extern MPI_Comm pcu_coll_comm;
+pcu_mpi_t* pcu_pmpi_init(MPI_Comm comm);
+void pcu_pmpi_finalize(pcu_mpi_t** m);
+int pcu_pmpi_size(pcu_mpi_t* self);
+int pcu_pmpi_rank(pcu_mpi_t* self);
+void pcu_pmpi_send(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
+bool pcu_pmpi_receive(pcu_mpi_t*, pcu_message* m, MPI_Comm comm);
+bool pcu_pmpi_done(pcu_mpi_t*, pcu_message* m);
 
 #endif


### PR DESCRIPTION
## Enable PCU to work without global/singleton data

This pull request adds a new public interface in `PCU2.h` that has every PCU function take the `pcu` state as it's first argument. This enables us to use PCU in a setting where we may have PCU operating over different communicator sets.

The other modification in this pull request is to remove the `vtable` from `pcu_pmpi` as it was used sporatically and the type was assumed most places. `pcu_mpi` and `pcu_pmpi` are not part of the public interface, so users should not have been making use of this interface.
