### PR TITLE
Fix CGNS

### DIFF
--- a/apf/apfCGNS.cc
+++ b/apf/apfCGNS.cc
@@ -1051,11 +1051,11 @@ void WriteCGNS(const char *prefix, apf::Mesh *m, const apf::CGNSBCMap &cgnsBCMap
   auto communicator = PCU_Get_Comm();
   cgp_mpi_comm(communicator);
   //
-  cgp_pio_mode(CGNS_ENUMV(CGP_INDEPENDENT));
+  cgp_pio_mode(CGP_INDEPENDENT);
 
   CGNS cgns;
   cgns.fname = std::string(prefix);
-  if (cgp_open(prefix, CGNS_ENUMV(CG_MODE_WRITE), &cgns.index))
+  if (cgp_open(prefix, CG_MODE_WRITE, &cgns.index))
     cgp_error_exit();
 
   {

--- a/mds/mdsCGNS.cc
+++ b/mds/mdsCGNS.cc
@@ -177,19 +177,19 @@ struct MeshDataGroup
     if (components.size() == 1)
     {
       std::cout << "Scalar Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else if (components.size() == 3)
     {
       std::cout << "Vector Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else if (components.size() == 9)
     {
       std::cout << "Matrix Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else
@@ -1056,8 +1056,8 @@ apf::Mesh2 *DoIt(gmi_model *g, const std::string &fname, apf::CGNSBCMap &cgnsBCM
   int cgid = -1;
   auto comm = PCU_Get_Comm();
   cgp_mpi_comm(comm);
-  cgp_pio_mode(CGNS_ENUMV(CGP_INDEPENDENT));
-  cgp_open(fname.c_str(), CGNS_ENUMV(CG_MODE_READ), &cgid);
+  cgp_pio_mode(CGP_INDEPENDENT);
+  cgp_open(fname.c_str(), CG_MODE_READ, &cgid);
 
   int nbases = -1;
   cg_nbases(cgid, &nbases);


### PR DESCRIPTION
Removed `CGNS_ENUMV` usage for variables that didn't require it. Primary reason this worked before is that `CGNS_ENUMV` can be set such that it doesn't actually do anything, which is normally default. spack automatically enables it to prepend `CG_` to everything.

As for the other change, my compiler was giving:
```
/home/jrwrigh/software/core/mds/mdsCGNS.cc: In member function ‘void {anonymous}::MeshDataGroup::info() const’:
/home/jrwrigh/software/core/mds/mdsCGNS.cc:180:23: error: loop variable ‘m’ creates a copy from type ‘const std::pair<const int, {anonymous}::MeshData>’ [-Werror=range-loop-construct]
  180 |       for (const auto m : components)
      |                       ^
/home/jrwrigh/software/core/mds/mdsCGNS.cc:180:23: note: use reference type to prevent copying
  180 |       for (const auto m : components)
      |                       ^
      |                       &
/home/jrwrigh/software/core/mds/mdsCGNS.cc:186:23: error: loop variable ‘m’ creates a copy from type ‘const std::pair<const int, {anonymous}::MeshData>’ [-Werror=range-loop-construct]
  186 |       for (const auto m : components)
      |                       ^
/home/jrwrigh/software/core/mds/mdsCGNS.cc:186:23: note: use reference type to prevent copying
  186 |       for (const auto m : components)
      |                       ^
      |                       &
/home/jrwrigh/software/core/mds/mdsCGNS.cc:192:23: error: loop variable ‘m’ creates a copy from type ‘const std::pair<const int, {anonymous}::MeshData>’ [-Werror=range-loop-construct]
  192 |       for (const auto m : components)
      |                       ^
/home/jrwrigh/software/core/mds/mdsCGNS.cc:192:23: note: use reference type to prevent copying
  192 |       for (const auto m : components)
      |                       ^
      |                       &
cc1plus: all warnings being treated as errors
```

So I followed it's suggestion. I'll be honest, I don't know C++ super well, so I have no idea what the problem is (but kind of understand the solution).


