### PR TITLE
Add compile_commands.json and .cache to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 build
 settings.json
+
+## LSP data
+.cache
+compile_commands.json


### PR DESCRIPTION
`.cache` directory holds `clangd` cached data, while `compile_commands.json` is read by `clangd`. Neither of these should be included in the repository.