### PR TITLE
Prepare and write CGNS boundary connectivity and ZoneBC in one base

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,9 +16,7 @@ option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" NO)
 #requre c++11 without extensions
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSION OFF)
-if(NOT ENABLE_CGNS)
-  set(CMAKE_CXX_STANDARD 11)
-endif()
+set(CMAKE_CXX_STANDARD 11)
 
 xsdk_begin_package()
 bob_begin_package()
@@ -27,8 +25,7 @@ if(USE_XSDK_DEFAULTS)
   xsdk_compiler_flags()
 endif()
 
-# require c++14
-option(ENABLE_CGNS "Enable the CGNS reader: requires c++14 extensions" OFF)
+option(ENABLE_CGNS "Enable the CGNS reader" OFF)
 message(STATUS "ENABLE_CGNS: ${ENABLE_CGNS}")
 
 # Set some default compiler flags that should always be used
@@ -37,10 +34,7 @@ if(NOT USE_XSDK_DEFAULTS)
   bob_begin_cxx_flags()
   bob_end_cxx_flags()
   set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
-  if(ENABLE_CGNS) #takes precedence over SCOREC_ENABLE_CXX11
-    message(STATUS "enabling cxx14")
-    bob_cxx14_flags()
-  elseif(SCOREC_ENABLE_CXX11)
+  if(SCOREC_ENABLE_CXX11)
     bob_cxx11_flags()
   endif()
 endif()
@@ -60,6 +54,8 @@ message(STATUS "IS_TESTING: ${IS_TESTING}")
 
 set(MESHES "${CMAKE_SOURCE_DIR}/pumi-meshes" CACHE STRING "Directory of test meshes")
 message(STATUS "MESHES: ${MESHES}")
+get_filename_component(MESHES ${MESHES} ABSOLUTE)
+message(STATUS "Using absolute file path MESHES: ${MESHES}")
 
 option(BUILD_EXES "Build executables" ON)
 message(STATUS "BUILD_EXES: ${BUILD_EXES}")
@@ -142,6 +138,14 @@ if(ENABLE_CGNS)
   set(SCOREC_USE_HDF5_DEFAULT ${ENABLE_CGNS})
   bob_public_dep(HDF5)
   add_definitions(-DHAVE_CGNS)
+else()
+  set(SCOREC_USE_CGNS_DEFAULT ${ENABLE_CGNS})
+  bob_public_dep(CGNS)
+  #CGNS does not provide cmake targets :(
+  include_directories(SYSTEM ${CGNS_INCLUDE_DIR})
+  set(SCOREC_USE_HDF5_DEFAULT ${ENABLE_CGNS})
+  bob_public_dep(HDF5)
+  add_definitions(-DHAVE_CGNS)
 endif()
 
 # Include the SCOREC project packages
@@ -172,8 +176,10 @@ add_library(core INTERFACE)
 target_link_libraries(core INTERFACE ${SCOREC_EXPORTED_TARGETS})
 if(ENABLE_CGNS)
   target_link_libraries(core INTERFACE ${CMAKE_DL_LIBS}) #HDF5 uses dlopen
-  target_compile_features(core INTERFACE cxx_std_14)
+  # target_compile_features(core INTERFACE cxx_std_14)
+  target_compile_features(core INTERFACE cxx_std_11)
 else()
+  target_link_libraries(core INTERFACE ${CMAKE_DL_LIBS}) #HDF5 uses dlopen
   target_compile_features(core INTERFACE cxx_std_11)
 endif()
 scorec_export_library(core)

--- a/apf/apfCGNS.cc
+++ b/apf/apfCGNS.cc
@@ -11,6 +11,7 @@
 #include "apfNumberingClass.h"
 #include "apfShape.h"
 #include "apfFieldData.h"
+#include <functional>
 #include <pcu_util.h>
 #include <lionPrint.h>
 //
@@ -269,9 +270,16 @@ void WriteTags(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity *
   }
 }
 */
-void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity *>> &orderedEnts, const std::vector<std::pair<cgsize_t, cgsize_t>> &ranges, const std::vector<apf::MeshEntity *> &orderedVertices, const int &vStart, const int &vEnd, apf::Mesh *m)
+
+typedef std::vector<apf::MeshEntity *> VecMeshEntity_t;
+typedef std::pair<cgsize_t, cgsize_t> CGRange_t;
+
+void WriteFields(const CGNS &cgns, const std::vector<VecMeshEntity_t> &orderedEnts, const std::vector<CGRange_t> &ranges, const VecMeshEntity_t &orderedVertices, const int &vStart, const int &vEnd, apf::Mesh *m)
 {
-  const auto writeField = [&m, &cgns](apf::Field *f, const auto &orderedEnts, const int &solIndex, const auto &inner, const auto &post, const int &numComponents, const int &component, const std::string &fieldName, const int &start, const int &end, int &fieldIndex) {
+  typedef std::function<void (apf::MeshEntity *elem, apf::FieldDataOf<double> *fieldData, std::vector<double> &ddata, const int &numComponents, const int &component)>  innerLambda_t;
+  typedef std::function<void (const int &solIndex, std::vector<double> &ddata, const cgsize_t *rmin, const cgsize_t *rmax, const int &globalSize, const int &fieldIndex)> postLambda_t;
+
+  const auto writeField = [&m, &cgns](apf::Field *f, const VecMeshEntity_t  &orderedEnt, const int &solIndex, const innerLambda_t &inner, const postLambda_t &post, const int &numComponents, const int &component, const std::string &fieldName, const int &start, const int &end, int &fieldIndex) {
     std::vector<double> data;
 
     cgsize_t rmin[3];
@@ -281,7 +289,7 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
     rmax[0] = end;
 
     apf::FieldDataOf<double> *fieldData = f->getData();
-    for (const auto &e : orderedEnts)
+    for (const auto &e : orderedEnt)
     {
       if (fieldData->hasEntity(e) && m->isOwned(e))
       {
@@ -310,7 +318,7 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
     }
   };
 
-  const auto loopCellFields = [&m, &writeField](const auto &orderedEnts, const int &solIndex, const auto &inner, const auto &post, const auto &ranges) {
+  const auto loopCellFields = [&m, &writeField](const std::vector<VecMeshEntity_t> &orderedEnts, const int &solIndex, const innerLambda_t &inner, const postLambda_t &post, const std::vector<CGRange_t> &ranges) {
     for (int i = 0; i < m->countFields(); ++i)
     {
       apf::Field *f = m->getField(i);
@@ -335,7 +343,7 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
     }
   };
 
-  const auto loopVertexFields = [&m, &writeField](const auto &orderedEnts, const int &solIndex, const auto &inner, const auto &post, const int &vStart, const int &vEnd) {
+  const auto loopVertexFields = [&m, &writeField](const VecMeshEntity_t &orderedVertices, const int &solIndex, const innerLambda_t &inner, const postLambda_t &post, const int &vStart, const int &vEnd) {
     for (int i = 0; i < m->countFields(); ++i)
     {
       apf::Field *f = m->getField(i);
@@ -352,12 +360,12 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
           fieldNameNew += "_[" + std::to_string(component) + "]";
 
         //std::cout << "VERTEX " << fieldNameNew << " " << fieldName << " " << component << " " << numComponents << std::endl;
-        writeField(f, orderedEnts, solIndex, inner, post, numComponents, component, fieldNameNew, vStart, vEnd, fieldIndex);
+        writeField(f, orderedVertices, solIndex, inner, post, numComponents, component, fieldNameNew, vStart, vEnd, fieldIndex);
       }
     }
   };
 
-  const auto postLambda = [&cgns](const int &solIndex, std::vector<double> &ddata, const cgsize_t *rmin, const cgsize_t *rmax, const int &globalSize, const int &fieldIndex) {
+  const postLambda_t postLambda = [&cgns](const int &solIndex, std::vector<double> &ddata, const cgsize_t *rmin, const cgsize_t *rmax, const int &globalSize, const int &fieldIndex) {
     if (globalSize > 0)
     {
       if (cgp_field_write_data(cgns.index, cgns.base, cgns.zone, solIndex, fieldIndex, &rmin[0], &rmax[0],
@@ -366,7 +374,7 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
     }
   };
 
-  const auto innerLambda = [](apf::MeshEntity *elem, apf::FieldDataOf<double> *fieldData, std::vector<double> &ddata, const int &numComponents, const int &component) {
+  const innerLambda_t innerLambda = [](apf::MeshEntity *elem, apf::FieldDataOf<double> *fieldData, std::vector<double> &ddata, const int &numComponents, const int &component) {
     std::vector<double> vals(numComponents, -12345);
     fieldData->get(elem, vals.data());
     //std::cout << numComponents << " " << component << " " << vals[0] << std::endl;
@@ -390,7 +398,7 @@ void WriteFields(const CGNS &cgns, const std::vector<std::vector<apf::MeshEntity
   }
 }
 
-auto WriteVertices(const CGNS &cgns, apf::Mesh *m, apf::GlobalNumbering *gvn)
+std::tuple<VecMeshEntity_t, int, int> WriteVertices(const CGNS &cgns, apf::Mesh *m, apf::GlobalNumbering *gvn)
 {
   int Cx = -1;
   int Cy = -1;
@@ -412,7 +420,7 @@ auto WriteVertices(const CGNS &cgns, apf::Mesh *m, apf::GlobalNumbering *gvn)
       cgp_error_exit();
   }
 
-  std::vector<apf::MeshEntity *> orderedVertices;
+  VecMeshEntity_t orderedVertices;
   cgsize_t vertexMin[3];
   cgsize_t vertexMax[3];
   cgsize_t contigRange = -1;
@@ -574,7 +582,10 @@ CellElementReturn WriteElements(const CGNS &cgns, apf::Mesh *m, apf::GlobalNumbe
 
 void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, const int &cellCount, apf::Mesh *m, const apf::CGNSBCMap &cgnsBCMap, const std::map<apf::Mesh::Type, CGNS_ENUMT(ElementType_t)> &apf2cgns, apf::GlobalNumbering *gvn)
 {
-  const auto EdgeLoop = [&m](const auto &lambda, apf::MeshTag *edgeTag) {
+  typedef std::function<void(apf::MeshEntity*)> LambdaMeshEntity_t;
+  typedef std::vector<apf::CGNSInfo> VecCGNSInfo_t;
+
+  const auto EdgeLoop = [&m](const LambdaMeshEntity_t &lambda, apf::MeshTag *edgeTag) {
     apf::MeshIterator *edgeIter = m->begin(1);
     apf::MeshEntity *edge = nullptr;
     int vals[1];
@@ -591,7 +602,7 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
     m->end(edgeIter);
   };
 
-  const auto FaceLoop = [&m](const auto &lambda, apf::MeshTag *faceTag) {
+  const auto FaceLoop = [&m](const LambdaMeshEntity_t &lambda, apf::MeshTag *faceTag) {
     apf::MeshIterator *faceIter = m->begin(2);
     apf::MeshEntity *face = nullptr;
     int vals[1];
@@ -608,7 +619,8 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
     m->end(faceIter);
   };
 
-  const auto BCEntityAdder = [&apf2cgns, &m, &cgns, &gvn](const auto &Looper, const auto &bcGroup, int &startingLocation) {
+  
+  const auto BCEntityAdder = [&apf2cgns, &m, &cgns, &gvn](const std::function<void(LambdaMeshEntity_t, apf::MeshTag*)> &Looper, const apf::CGNSInfo &bcGroup, int &startingLocation) {
     std::map<apf::Mesh::Type, std::vector<apf::MeshEntity *>> bcEntTypes;
     for (const auto &r : apf2cgns)
       bcEntTypes.insert(std::make_pair(r.first, std::vector<apf::MeshEntity *>()));
@@ -715,7 +727,9 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
                    PCU_Get_Comm());
   };
 
-  const auto doVertexBC = [&](const auto &iter) {
+  typedef std::map<std::basic_string<char>, std::vector<apf::CGNSInfo>>::const_iterator  MapCGNSInfo_t;
+
+  const auto doVertexBC = [&](const MapCGNSInfo_t &iter) {
     for (const auto &p : iter->second)
     {
       std::vector<cgsize_t> bcList;
@@ -751,7 +765,7 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
     }
   };
 
-  const auto doEdgeBC = [&](const auto &iter, int &startingLocation) {
+  const auto doEdgeBC = [&](const MapCGNSInfo_t &iter, int &startingLocation) {
     for (const auto &p : iter->second)
     {
       const auto se = BCEntityAdder(EdgeLoop, p, startingLocation);
@@ -774,7 +788,7 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
     }
   };
 
-  const auto doFaceBC = [&](const auto &iter, int &startingLocation) {
+  const auto doFaceBC = [&](const MapCGNSInfo_t &iter, int &startingLocation) {
     for (const auto &p : iter->second)
     {
       const auto se = BCEntityAdder(FaceLoop, p, startingLocation);
@@ -797,7 +811,7 @@ void AddBocosToMainBase(const CGNS &cgns, const CellElementReturn &cellResults, 
     }
   };
 
-  const auto doCellBC = [&](const auto &iter, const int &) {
+  const auto doCellBC = [&](const MapCGNSInfo_t &iter, const int &) {
     for (const auto &p : iter->second)
     {
       std::vector<cgsize_t> bcList;
@@ -1051,11 +1065,11 @@ void WriteCGNS(const char *prefix, apf::Mesh *m, const apf::CGNSBCMap &cgnsBCMap
   auto communicator = PCU_Get_Comm();
   cgp_mpi_comm(communicator);
   //
-  cgp_pio_mode(CGNS_ENUMV(CGP_INDEPENDENT));
+  cgp_pio_mode(CGP_INDEPENDENT);
 
   CGNS cgns;
   cgns.fname = std::string(prefix);
-  if (cgp_open(prefix, CGNS_ENUMV(CG_MODE_WRITE), &cgns.index))
+  if (cgp_open(prefix, CG_MODE_WRITE, &cgns.index))
     cgp_error_exit();
 
   {

--- a/mds/mdsCGNS.cc
+++ b/mds/mdsCGNS.cc
@@ -177,19 +177,19 @@ struct MeshDataGroup
     if (components.size() == 1)
     {
       std::cout << "Scalar Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else if (components.size() == 3)
     {
       std::cout << "Vector Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else if (components.size() == 9)
     {
       std::cout << "Matrix Group has " << components.size() << " related componenets: " << std::endl;
-      for (const auto m : components)
+      for (const auto &m : components)
         std::cout << "Field " << m.second.name << " @ " << m.second.si << " " << m.second.fi << std::endl;
     }
     else
@@ -265,7 +265,7 @@ void Kill(const int fid)
   }
 }
 
-auto ReadCGNSCoords(int cgid, int base, int zone, int ncoords, int nverts, const std::vector<cgsize_t> &, const apf::GlobalToVert &globalToVert)
+std::map<int, std::array<double, 3>> ReadCGNSCoords(int cgid, int base, int zone, int ncoords, int nverts, const std::vector<cgsize_t> &, const apf::GlobalToVert &globalToVert)
 {
   // Read min required as defined by consecutive range
   // make one based as ReadElements makes zero based
@@ -389,7 +389,7 @@ void SimpleElementPartition(std::vector<cgsize_t> &numberToReadPerProc, std::vec
 using Pair = std::pair<cgsize_t, cgsize_t>;
 using LocalElementRanges = std::vector<Pair>; // one based
 
-auto ReadElements(int cgid, int base, int zone, int section, int el_start /* one based */, int el_end, int numElements, int verticesPerElement, LocalElementRanges &localElementRanges)
+std::tuple<std::vector<cgsize_t>, cgsize_t> ReadElements(int cgid, int base, int zone, int section, int el_start /* one based */, int el_end, int numElements, int verticesPerElement, LocalElementRanges &localElementRanges)
 {
   std::vector<cgsize_t> numberToReadPerProc;
   std::vector<cgsize_t> startingIndex;
@@ -1056,8 +1056,8 @@ apf::Mesh2 *DoIt(gmi_model *g, const std::string &fname, apf::CGNSBCMap &cgnsBCM
   int cgid = -1;
   auto comm = PCU_Get_Comm();
   cgp_mpi_comm(comm);
-  cgp_pio_mode(CGNS_ENUMV(CGP_INDEPENDENT));
-  cgp_open(fname.c_str(), CGNS_ENUMV(CG_MODE_READ), &cgid);
+  cgp_pio_mode(CGP_INDEPENDENT);
+  cgp_open(fname.c_str(), CG_MODE_READ, &cgid);
 
   int nbases = -1;
   cg_nbases(cgid, &nbases);

--- a/test/cgns.cc
+++ b/test/cgns.cc
@@ -119,7 +119,7 @@ pMesh toPumi(const std::string &prefix, gmi_model *g, apf::Mesh2 *mesh)
   return pm;
 }
 
-auto additional(const std::string &prefix, gmi_model *g, apf::Mesh2 *mesh)
+std::function<void()> additional(const std::string &prefix, gmi_model *g, apf::Mesh2 *mesh)
 {
   // seems essential to make pm first before calling balance or reorder...
   auto pm = toPumi(prefix, g, mesh);

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -560,7 +560,7 @@ mpi_test(cgns_3d_2 ${numProcs}
 #
 # 3D BCS tests
 #
-set(numProcs 5)
+set(numProcs 4)
 #
 set(CGNSDIR ${MESHES}/cgns/withBCS/3D)
 #


### PR DESCRIPTION
## Prepare and write CGNS boundary connectivity and ZoneBC in one base

This is a WIP as we hope to coordinate the code development through this PR.  Currently SCOREC/core prepares a broad variety of meshes, boundary conditions, initial conditions, and partitions of the same for the PHASTA flow solver with the application chef.  That data is currently written for each part of the partition in what is referred to as PHASTA POSIX file format.  

CEED-PHASTA, being built on PETSc already has CGNS writing and growing CGNS reading capability.   The PR seeks to leverage meshes already in the mds database (that are usually classified against a model that has initial condition and boundary condition attributes). The developments of the PR will further leverage the routines that extract the volume mesh (coordinates and connectivity), initial conditions on the volume mesh entities,  and  the boundary element mesh (one boundary element connectivity per surface). Once this data is extracted into data structures,  the existing CGNS writing capability will be modified to write all the above data in a single "base" so that it can be read by PETSc and applied in the CEED-PHASTA solver.

The first test will be a simple flow through a box but more extensive tests will be developed as more capabilities are added.

