### PR TITLE
Initialize ma::Input::debugFolder and default to working directory

### DIFF
--- a/ma/maDBG.cc
+++ b/ma/maDBG.cc
@@ -204,7 +204,9 @@ void dumpMeshWithFlag(ma::Adapt* a,
 
   // setup file name and write the mesh
   std::stringstream ss;
-  ss << a->input->debugFolder << "/";
+  if (a->input->debugFolder) {
+    ss << a->input->debugFolder << "/";
+  }
   ss << prefix << "_" << std::setfill('0') << std::setw(3) << iter;
 
   writeMesh(a->mesh, ss.str().c_str(), "");

--- a/ma/maDBG.cc
+++ b/ma/maDBG.cc
@@ -163,7 +163,9 @@ void dumpMeshWithQualities(ma::Adapt* a,
   // setup file name and write the mesh
   std::stringstream ss;
 
-  ss << a->input->debugFolder << "/";
+  if (a->input->debugFolder) {
+    ss << a->input->debugFolder << "/";
+  }
   ss << std::setfill('0') << std::setw(3) << iter << "_";
   ss << prefix;
 

--- a/ma/maInput.cc
+++ b/ma/maInput.cc
@@ -63,6 +63,7 @@ void setDefaultValues(Input* in)
   in->splitAllLayerEdges = false;
   in->userDefinedLayerTagName = "";
   in->shapeHandler = 0;
+  in->debugFolder = nullptr;
 }
 
 void rejectInput(const char* str)


### PR DESCRIPTION
## Initialize ma::Input::debugFolder and default to working directory
- Update setDefaultValues().
- Check for debugFolder in verbose ma::adaptVerbose.
- This fixes a segfault when calling ma::adaptVerbose(in, true) without setting in->debugFolder first.
- Previously, not explicitly setting debugFolder was undefined behavior
- Now, when debugFolder is not set, debug mesh VTKs are placed in the working directory.
