### PR TITLE
Fix find_package_handle_standard_args capitalization

### DIFF
--- a/cmake/FindParmetis.cmake
+++ b/cmake/FindParmetis.cmake
@@ -40,7 +40,7 @@ set(PARMETIS_INCLUDE_DIRS ${PARMETIS_INCLUDE_DIR} ${METIS_INCLUDE_DIR})
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set PARMETIS_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(PARMETIS  DEFAULT_MSG
+find_package_handle_standard_args(Parmetis  DEFAULT_MSG
     PARMETIS_LIBRARY METIS_LIBRARY PARMETIS_INCLUDE_DIR)
 
 mark_as_advanced(PARMETIS_INCLUDE_DIR PARMETIS_LIBRARY METIS_LIBRARY)

--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -174,7 +174,7 @@ endif()
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set SIMMODSUITE_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(SIMMODSUITE  DEFAULT_MSG
+find_package_handle_standard_args(SimModSuite  DEFAULT_MSG
   SIMMODSUITE_LIBS SIMMODSUITE_INCLUDE_DIR
   SIMMODSUITE_MAJOR_VERSION SIMMODSUITE_MINOR_VERSION)
 

--- a/cmake/FindZoltan.cmake
+++ b/cmake/FindZoltan.cmake
@@ -23,7 +23,7 @@ include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set ZOLTAN_FOUND to TRUE
 # if all listed variables are TRUE
 find_package_handle_standard_args(
-    ZOLTAN
+    Zoltan
     DEFAULT_MSG
     ZOLTAN_LIBRARY ZOLTAN_INCLUDE_DIR
 )


### PR DESCRIPTION
## Fix find_package_handle_standard_args capitalization
Fix CMake warning for non-matching case of requested and found package.
Removes warnings from requesting SIMMODSUITE, ZOLTAN, and PARMETIS.
Now SimModSuite, Zoltan, and Parmetis are requested and put into the same variables.