### PR TITLE
Add apf_cap to core interface and optional capstone_clis exes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,8 @@ add_subdirectory(phasta)
 add_subdirectory(stk)
 add_subdirectory(dsp)
 add_subdirectory(omega_h)
+add_subdirectory(gmi_cap)
+add_subdirectory(apf_cap)
 
 # this INTERFACE target bundles all the enabled libraries together
 add_library(core INTERFACE)
@@ -200,16 +202,11 @@ endif()
 
 if(BUILD_EXES)
   add_subdirectory(test)
+  add_subdirectory(capstone_clis)
 endif()
 
 if(PUMI_PYTHON_INTERFACE)
   add_subdirectory(python_wrappers)
-endif()
-
-if(ENABLE_CAPSTONE)
-  add_subdirectory(gmi_cap)
-  add_subdirectory(apf_cap)
-  add_subdirectory(capstone_clis)
 endif()
 
 bob_end_package()

--- a/apf_cap/CMakeLists.txt
+++ b/apf_cap/CMakeLists.txt
@@ -3,6 +3,10 @@ if(DEFINED TRIBITS_PACKAGE)
   return()
 endif()
 
+if(NOT ENABLE_CAPSTONE)
+  return()
+endif()
+
 #Sources & Headers
 set(SOURCES apfCAP.cc)
 set(HEADERS apfCAP.h)


### PR DESCRIPTION
Fix apf_cap to be like gmi_cap and apf_sim (immediate return if not capstone) Now apf_cap links correctly.
This allows users of SCOREC to link to SCOREC::core instead of having to add SCOREC::apf_cap.