### PR TITLE
Fix outdated reel_fail call

### DIFF
--- a/pcu/reel/reel.c
+++ b/pcu/reel/reel.c
@@ -59,6 +59,6 @@ void reel_protect(void)
 #else
 void reel_protect(void)
 {
-  reel_fail(stderr, "reel_protect only supported on Linux and OS X");
+  reel_fail("reel_protect only supported on Linux and OS X");
 }
 #endif


### PR DESCRIPTION
## Fix outdated reel_fail call

This fixes an outdated reel_fail call on non-Linux non-OS X systems. Presumably the macro took a `FILE*` at some point.