### PR TITLE
Fix test/capVol CMake and compiler warnings

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -211,7 +211,7 @@ endif()
 
 if(ENABLE_CAPSTONE)
   util_exe_func(capVol capVol.cc)
-  target_include_directories(capVol PUBLIC "${PROJECT_SOURCE_DIR}/capstone_clis")
+  target_include_directories(capVol PRIVATE "${PROJECT_SOURCE_DIR}/capstone_clis")
 endif()
 
 # send all the newly added utility executable targets

--- a/test/capVol.cc
+++ b/test/capVol.cc
@@ -95,13 +95,9 @@ int main(int argc, char** argv) {
   bool volume_flag = false, write_flag = false, analytic_flag = false,
        verbose_flag = false;
   for (int i = 1; i < argc - 2; ++i) {
-    bool flagDone = false;
     if (*argv[i] == '-') {
       for (int j = 1; argv[i][j] != '\0'; ++j) {
         switch(argv[i][j]) {
-        case '-':
-          flagDone = true;
-          break;
         case 'a':
           analytic_flag = true;
           break;


### PR DESCRIPTION
## Fix test/capVol CMake and compiler warnings

Remove partial support for -- to end command line option processing
- This did not make sense anyway since the final two arguments are never processed. Make the include_directories PRIVATE to the executable target

This PR fixes warnings that I noticed with SCOREC_CXX_WARNINGS=ON.