### PR TITLE
Support Builds with Simmetrix SimModSuite on RHEL8/9 Systems

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -84,7 +84,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 15.0.191017)
-set(MAX_VALID_SIM_VERSION 18.0.220930)
+set(MAX_VALID_SIM_VERSION 2023.1.230907)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")

--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -171,10 +171,23 @@ if (UNIX AND NOT APPLE)
   set(SIMMODSUITE_LIBS ${SIMMODSUITE_LIBS} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
+if (SIM_ARCHOS STREQUAL x64_rhel8_gcc83)
+  find_library(XDR_LIB tirpc)
+  if(XDR_LIB)
+    message(STATUS "Found XDR_LIB ${XDR_LIB}")
+    set(SIMMODSUITE_LIBS ${SIMMODSUITE_LIBS} ${XDR_LIB})
+  else()
+    message(FATAL_ERROR "The libtirpc library was not found.  It defines xdr symbols "
+    "(e.g., xdrmem_create) that are need by SimModSuite on systems using "
+    "glibc newer than 2.32.  Note, glibc starting with 2.26 could optionally "
+    "have been built without the xdr symbols.")
+  endif()
+endif()
+
 include(FindPackageHandleStandardArgs)
 # handle the QUIETLY and REQUIRED arguments and set SIMMODSUITE_FOUND to TRUE
 # if all listed variables are TRUE
-find_package_handle_standard_args(SIMMODSUITE  DEFAULT_MSG
+find_package_handle_standard_args(SimModSuite  DEFAULT_MSG
   SIMMODSUITE_LIBS SIMMODSUITE_INCLUDE_DIR
   SIMMODSUITE_MAJOR_VERSION SIMMODSUITE_MINOR_VERSION)
 


### PR DESCRIPTION
On RHEL8/9 systems `libtirpc` is required by SimModSuite.  This PR adds logic to find that library and list it with the SimModSuite libs.

This issue is also discussed in:
https://github.com/SCOREC/core/issues/367
