### PR TITLE
Simmetrix SimModSuite support update

### DIFF
--- a/apf_sim/CMakeLists.txt
+++ b/apf_sim/CMakeLists.txt
@@ -7,19 +7,6 @@ if(NOT ENABLE_SIMMETRIX)
   return()
 endif()
 
-option(ENABLE_FIELDSIM "Enable use of FieldSim from Simmetrix SimModSuite" FALSE)
-message(STATUS "ENABLE_FIELDSIM: ${ENABLE_FIELDSIM}")
-set(USE_FIELDSIM FALSE)
-if( ${SIMMODSUITE_SimField_FOUND} AND ENABLE_FIELDSIM )
-  set(USE_FIELDSIM TRUE)
-endif()
-set(USE_SIM_ADVMESHING ${HAVE_SIMADVMESHING})
-
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/apf_simConfig.h.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h")
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h
-        DESTINATION include)
 
 #Sources & Headers
 set(SOURCES apfSIM.cc)
@@ -35,6 +22,19 @@ target_include_directories(apf_sim PUBLIC
     $<INSTALL_INTERFACE:include>
     )
 
+option(ENABLE_FIELDSIM "Enable use of FieldSim from Simmetrix SimModSuite" FALSE)
+message(STATUS "ENABLE_FIELDSIM: ${ENABLE_FIELDSIM}")
+set(USE_FIELDSIM FALSE)
+if( ${SIMMODSUITE_SimField_FOUND} AND ENABLE_FIELDSIM )
+  set(USE_FIELDSIM TRUE)
+endif()
+set(USE_SIM_ADVMESHING ${HAVE_SIMADVMESHING})
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/apf_simConfig.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h
+        DESTINATION include)
 #directory containing apf_simConfig.h
 target_include_directories(apf_sim PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)

--- a/apf_sim/CMakeLists.txt
+++ b/apf_sim/CMakeLists.txt
@@ -7,6 +7,20 @@ if(NOT ENABLE_SIMMETRIX)
   return()
 endif()
 
+option(ENABLE_FIELDSIM "Enable use of FieldSim from Simmetrix SimModSuite" FALSE)
+message(STATUS "ENABLE_FIELDSIM: ${ENABLE_FIELDSIM}")
+set(USE_FIELDSIM FALSE)
+if( ${SIMMODSUITE_SimField_FOUND} AND ENABLE_FIELDSIM )
+  set(USE_FIELDSIM TRUE)
+endif()
+set(USE_SIM_ADVMESHING ${HAVE_SIMADVMESHING})
+
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/apf_simConfig.h.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h
+        DESTINATION include)
+
 #Sources & Headers
 set(SOURCES apfSIM.cc)
 set(HEADERS apfSIM.h)
@@ -21,20 +35,10 @@ target_include_directories(apf_sim PUBLIC
     $<INSTALL_INTERFACE:include>
     )
 
-option(ENABLE_FIELDSIM "Enable use of FieldSim from Simmetrix SimModSuite" FALSE)
-message(STATUS "ENABLE_FIELDSIM: ${ENABLE_FIELDSIM}")
-set(USE_FIELDSIM FALSE)
-if( ${SIMMODSUITE_SimField_FOUND} AND ENABLE_FIELDSIM )
-  set(USE_FIELDSIM TRUE)
-endif()
-set(USE_SIM_ADVMESHING ${HAVE_SIMADVMESHING})
-
-configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/apf_simConfig.h.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/apf_simConfig.h")
 #directory containing apf_simConfig.h
-target_include_directories(apf_sim PRIVATE
+target_include_directories(apf_sim PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>)
+
 
 scorec_export_library(apf_sim)
 

--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -84,7 +84,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 15.0.191017)
-set(MAX_VALID_SIM_VERSION 2023.1.230907)
+set(MAX_VALID_SIM_VERSION 2024.0.240219)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")

--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -110,6 +110,17 @@ math(EXPR len "${archEnd}-${archStart}")
 string(SUBSTRING "${SIMMODSUITE_LIBS}" "${archStart}" "${len}" SIM_ARCHOS)
 message(STATUS "SIM_ARCHOS ${SIM_ARCHOS}")
 
+set(SIM_OPT_LIB_NAMES
+  SimAdvMeshing
+  SimField)
+
+simLibCheck("${SIM_OPT_LIB_NAMES}" FALSE)
+
+option(SIM_DISCRETE "Use Simmetrix discrete modeling" ON)
+if (SIM_DISCRETE)
+  set(SIM_CAD_LIB_NAMES SimDiscrete ${SIM_CAD_LIB_NAMES})
+endif()
+
 option(SIM_PARASOLID "Use Parasolid through Simmetrix" OFF)
 if (SIM_PARASOLID)
   set(MIN_SIM_PARASOLID_VERSION 290)
@@ -130,6 +141,7 @@ if (SIM_PARASOLID)
       "not found - check the version installed with SimModSuite")
   endif()
   set(SIM_CAD_LIB_NAMES
+    ${SIM_CAD_LIB_NAMES}
     ${simParaLib}
     pskernel)
 endif()
@@ -139,30 +151,19 @@ if (SIM_ACIS)
   getSimCadLib("${SIMMODSUITE_INSTALL_DIR}/lib/${SIM_ARCHOS}"
     SimAcis simAcisLib TRUE)
   set(SIM_CAD_LIB_NAMES
-      ${simAcisLib}
       ${SIM_CAD_LIB_NAMES}
+      ${simAcisLib}
       SpaACIS)
-endif()
-
-option(SIM_DISCRETE "Use Simmetrix discrete modeling" ON)
-if (SIM_DISCRETE)
-  set(SIM_CAD_LIB_NAMES SimDiscrete ${SIM_CAD_LIB_NAMES})
 endif()
 
 simLibCheck("${SIM_CAD_LIB_NAMES}" TRUE)
 
-set(SIM_OPT_LIB_NAMES
-  SimField
-  SimAdvMeshing)
-
-simLibCheck("${SIM_OPT_LIB_NAMES}" FALSE)
-
 set(SIM_CORE_LIB_NAMES
   SimPartitionedMesh-mpi
+  SimPartitionWrapper-${SIM_MPI}
   SimMeshing
   SimMeshTools
-  SimModel
-  SimPartitionWrapper-${SIM_MPI})
+  SimModel)
 
 simLibCheck("${SIM_CORE_LIB_NAMES}" TRUE)
 

--- a/phasta/phAttrib.cc
+++ b/phasta/phAttrib.cc
@@ -6,7 +6,7 @@
 #include <SimModel.h>
 #include <cstdlib>
 #include <iostream>
-
+#include "apf_simConfig.h"
 
 typedef ph::BC* (*BCFactory)(pAttribute a, pGEntity ge);
 typedef std::map<std::string, BCFactory> BCFactories;

--- a/phasta/phAttrib.cc
+++ b/phasta/phAttrib.cc
@@ -3,13 +3,10 @@
 #include <lionPrint.h>
 #include <SimAttribute.h>
 #include <SimUtil.h>
+#include <SimModel.h>
 #include <cstdlib>
 #include <iostream>
 
-/* Simmetrix, for the love of all that is good,
-   please put this in your header files.
-   We can't work with files from Simmodeler without it. */
-pAManager SModel_attManager(pModel model);
 
 typedef ph::BC* (*BCFactory)(pAttribute a, pGEntity ge);
 typedef std::map<std::string, BCFactory> BCFactories;
@@ -224,7 +221,11 @@ static void addAttributes(BCFactories& fs, pPList as, pGEntity ge,
 namespace {
   void getSimModelAndCase(gmi_model* m, pGModel& smdl, pACase& pd) {
     smdl = gmi_export_sim(m);
-    pAManager mngr = SModel_attManager(smdl);
+#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+    pAManager mngr = GM_attManager(smdl);
+#else
+    pAManager mngr = GM_attManager(smdl,true);
+#endif
     if (!mngr) {
       lion_eprint(1,"Simmetrix model did not come with an Attribute Manager\n");
       abort();

--- a/phasta/phAttrib.cc
+++ b/phasta/phAttrib.cc
@@ -221,7 +221,7 @@ static void addAttributes(BCFactories& fs, pPList as, pGEntity ge,
 namespace {
   void getSimModelAndCase(gmi_model* m, pGModel& smdl, pACase& pd) {
     smdl = gmi_export_sim(m);
-#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+#if SIMMODSUITE_MAJOR_VERSION <= 2024 && SIMMODSUITE_MINOR_VERSION < 240219
     pAManager mngr = GM_attManager(smdl);
 #else
     pAManager mngr = GM_attManager(smdl,true);

--- a/phasta/phMeshQuality.cc
+++ b/phasta/phMeshQuality.cc
@@ -8,7 +8,6 @@
 #include <apfMatrix.h>
 #include <maSize.h>
 #include <maShape.h>
-//#include "apf_simConfig.h"
 
 #ifdef HAVE_SIMMETRIX
 #include <SimUtil.h>

--- a/test/generate.cc
+++ b/test/generate.cc
@@ -75,7 +75,7 @@ void messageHandler(int type, const char* msg)
 }
 
 pParMesh generate(pGModel mdl, std::string meshCaseName) {
-#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+#if SIMMODSUITE_MAJOR_VERSION <= 2024 && SIMMODSUITE_MINOR_VERSION < 240219
   pAManager attmngr = GM_attManager(mdl);
 #else
   pAManager attmngr = GM_attManager(mdl,true);

--- a/test/generate.cc
+++ b/test/generate.cc
@@ -1,6 +1,7 @@
 #include <PCU.h>
 #include <lionPrint.h>
 #include <MeshSim.h>
+#include <SimModel.h>
 #include <SimDiscrete.h>
 #include <SimAdvMeshing.h>
 #include <SimPartitionedMesh.h>
@@ -39,7 +40,6 @@
 #include "SimAttribute.h"
 #include "ModelTypes.h"
 
-pAManager SModel_attManager(pModel model);
 
 namespace {
 
@@ -74,7 +74,11 @@ void messageHandler(int type, const char* msg)
 }
 
 pParMesh generate(pGModel mdl, std::string meshCaseName) {
-  pAManager attmngr = SModel_attManager(mdl);
+#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+  pAManager attmngr = GM_attManager(mdl);
+#else
+  pAManager attmngr = GM_attManager(mdl,true);
+#endif
   if(0==PCU_Comm_Self())
     fprintf(stdout, "Loading mesh case %s...\n", meshCaseName.c_str());
   pACase mcaseFile = AMAN_findCase(attmngr, meshCaseName.c_str());

--- a/test/generate.cc
+++ b/test/generate.cc
@@ -10,6 +10,7 @@
 #include <SimUtil.h>
 #include <apfSIM.h>
 #include <apfMDS.h>
+#include <apf_simConfig.h>
 #include "gmi_sim_config.h"
 #include <gmi_sim.h>
 #include <apf.h>

--- a/test/rm_extrusion.cc
+++ b/test/rm_extrusion.cc
@@ -4,7 +4,7 @@
 #include <SimPartitionedMesh.h>
 #include <SimUtil.h>
 #include <apfSIM.h>
-#include <../apf_sim/apf_simConfig.h>
+#include <apf_simConfig.h>
 #include <apfMDS.h>
 #include <gmi.h>
 #include <gmi_sim.h>

--- a/test/simTranslate.cc
+++ b/test/simTranslate.cc
@@ -160,7 +160,7 @@ int main(int argc, char* argv[])
   if (argc == 4) {
     try {
       pGModel oldmodel = GM_load(argv[2], NULL, NULL);
-#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+#if SIMMODSUITE_MAJOR_VERSION <= 2024 && SIMMODSUITE_MINOR_VERSION < 240219
       attmngr = GM_attManager(oldmodel);
 #else
       attmngr = GM_attManager(oldmodel,true);

--- a/test/simTranslate.cc
+++ b/test/simTranslate.cc
@@ -18,8 +18,7 @@
 #include <stdlib.h>
 #include <string>
 
-/* hack to get SIMMODSUITE_MAJOR_VERSION and SIMMODSUITE_MINOR_VERSION */
-#include "../apf_sim/apf_simConfig.h"
+#include <apf_simConfig.h>
 /* cheap hackish way to get SIM_PARASOLID and SIM_ACIS */
 #include "gmi_sim_config.h"
 #include <gmi_sim.h>

--- a/test/simTranslate.cc
+++ b/test/simTranslate.cc
@@ -47,9 +47,6 @@ void messageHandler(int type, const char *msg);
 void progressHandler(const char *what, int level, int startVal, 
     int endVal, int currentVal, void *);
 
-void SModel_setAttManager(pModel model, pAManager attMan);
-pAManager SModel_attManager(pModel model);
-
 /* Constants (ugh -- FIXME) */
 static std::string acisExt = ".sat";
 static std::string paraExt = ".xmt_txt";
@@ -164,13 +161,17 @@ int main(int argc, char* argv[])
   if (argc == 4) {
     try {
       pGModel oldmodel = GM_load(argv[2], NULL, NULL);
-      attmngr = SModel_attManager(oldmodel);
+#if SIMMODSUITE_MAJOR_VERSION < 2024 && SIMMODSUITE_MINOR_VERSION < 240219
+      attmngr = GM_attManager(oldmodel);
+#else
+      attmngr = GM_attManager(oldmodel,true);
+#endif
       //attmngr = AMAN_load(argv[2]);
       if(!attmngr) {
         fprintf(stderr, "file \"%s\" contains no attributes", argv[2]);
         abort();
       }
-      SModel_setAttManager(simmodel, attmngr);
+      GM_setAttManager(simmodel, attmngr);
       pACase currentCase;
       pPList allCases = AMAN_cases(attmngr);
       void* iter = 0;


### PR DESCRIPTION
- fixes simmetrix static library linking order following 2024.0 documentation
- replaces use of hidden/internal APIs with public ones
- installs apf_simConfig.h to give access to compile time simmetrix version number macros
- increases newest supported simmodsuite version