### PR TITLE
fix gcc 12.3 -werror errors

### DIFF
--- a/phasta/phLinks.cc
+++ b/phasta/phLinks.cc
@@ -98,21 +98,21 @@ struct PhastaSharing : public apf::Sharing {
 
 void getLinks(apf::Mesh* m, int dim, Links& links, BCs& bcs)
 {
-  PhastaSharing shr(m);
+  PhastaSharing* shr = new PhastaSharing(m);
   PCU_Comm_Begin();
   apf::MeshIterator* it = m->begin(dim);
   apf::MeshEntity* v;
   while ((v = m->iterate(it))) {
     apf::ModelEntity* me = m->toModel(v);
-    shr.isDG = ph::isInterface(m->getModel(),(gmi_ent*) me,bcs.fields["DG interface"]);
+    shr->isDG = ph::isInterface(m->getModel(),(gmi_ent*) me,bcs.fields["DG interface"]);
 /* the alignment is such that the owner part's
    array follows the order of its vertex iterator
    traversal. The owner dictates the order to the
    other part by sending remote copies */
-    if ( ! shr.isOwned(v))
+    if ( ! shr->isOwned(v))
       continue;
     apf::CopyArray remotes;
-    shr.getCopies(v, remotes);
+    shr->getCopies(v, remotes);
     for (size_t i = 0; i < remotes.getSize(); ++i) {
       /* in matching we may accumulate multiple occurrences
          of the same master in the outgoing links array
@@ -131,6 +131,7 @@ void getLinks(apf::Mesh* m, int dim, Links& links, BCs& bcs)
       links[LinkKey(0, peer)].push_back(v);
     }
   }
+  delete shr;
 }
 
 /* encode the local links into a big array of integers

--- a/test/convert.cc
+++ b/test/convert.cc
@@ -358,6 +358,11 @@ void addFathersTag(pGModel simModel, pParMesh sim_mesh, apf::Mesh* simApfMesh, c
       for(i=0; i< nvert ; i++) {
         int* fatherIdPtr;
         const int exists = EN_getDataPtr((pEntity)vrts[i],myFather,(void**)&fatherIdPtr);
+        if(!exists) {
+          if(!PCU_Comm_Self())
+            fprintf(stderr, "Error: father id data pointer does not exist... exiting\n");
+          exit(EXIT_FAILURE);
+        }
         assert(exists);
         fatherIds[i] = fatherIdPtr[0];
         V_coord(vrts[i],coordFather[i]);


### PR DESCRIPTION
Building with Gcc 12.3 and all errors enabled results in the following errors:

## phLinks.cc

```
cd /space/cwsmith/pumiTestRhel9Sim/build/phasta && /opt/scorec/spack/rhel9/v0201_4/install/linux-rhel9-x86_64/gcc-12.3.0/mpich-4.1.1-xpoyz4tqgfxtrm6m7qq67q4ccp5pnlre/bin/mpicxx -DHAVE_CLOCK_GETTIME -DHAVE_SIMADVMESHING -DHAVE_SIMMETRIX -DOMPI_SKIP_MPICXX -DPUMI_HAS_ZOLTAN -I/space/cwsmith/pumiTestRhel9Sim/core/phasta -I/space/cwsmith/pumiTestRhel9Sim/core/ma -I/space/cwsmith/pumiTestRhel9Sim/core/apf -I/space/cwsmith/pumiTestRhel9Sim/core/pcu -I/space/cwsmith/pumiTestRhel9Sim/core/pcu/reel -I/space/cwsmith/pumiTestRhel9Sim/core/gmi -I/space/cwsmith/pumiTestRhel9Sim/core/lion -I/space/cwsmith/pumiTestRhel9Sim/core/can -I/space/cwsmith/pumiTestRhel9Sim/core/mth -I/space/cwsmith/pumiTestRhel9Sim/core/mds -I/space/cwsmith/pumiTestRhel9Sim/core/parma -I/space/cwsmith/pumiTestRhel9Sim/core/zoltan -I/space/cwsmith/pumiTestRhel9Sim/core/sam -I/space/cwsmith/pumiTestRhel9Sim/core/pumi -I/opt/scorec/spack/rhel9/v0201_4/install/linux-rhel9-x86_64/gcc-12.3.0/simmetrix-simmodsuite-2024.0-240119dev-7abimo4wnqjk3h53clpzpb4gqljxnl2v/include -I/space/cwsmith/pumiTestRhel9Sim/core/gmi_sim -I/space/cwsmith/pumiTestRhel9Sim/core/apf_sim -g -Werror -Wall -Wextra -Wno-strict-overflow  -O3 -DNDEBUG -std=gnu++11 -MD -MT phasta/CMakeFiles/ph.dir/phLinks.cc.o -MF CMakeFiles/ph.dir/phLinks.cc.o.d -o CMakeFiles/ph.dir/phLinks.cc.o -c /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc
In member function 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)',
    inlined from 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:43:30,
    inlined from 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:40:8,
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:112:23:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:42:9: error: array subscript 'ph::PhastaSharing[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds]
   42 |     if (isDG)
      |         ^~~~
In constructor 'ph::PhastaSharing::PhastaSharing(apf::Mesh*)',
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:101:22:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:24:39: note: object of size 16 allocated by 'operator new'
   24 |     helperN = new apf::NormalSharing(m);
      |                                       ^
In member function 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)',
    inlined from 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:43:30,
    inlined from 'virtual bool ph::PhastaSharing::isOwned(apf::MeshEntity*)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:40:8,
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:112:23:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:44:12: error: array subscript 'ph::PhastaSharing[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds]
   44 |     return helperM->isOwned(e);
      |            ^~~~~~~
In constructor 'ph::PhastaSharing::PhastaSharing(apf::Mesh*)',
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:101:22:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:24:39: note: object of size 16 allocated by 'operator new'
   24 |     helperN = new apf::NormalSharing(m);
      |                                       ^
In member function 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)',
    inlined from 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:51:25,
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:115:18:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:50:9: error: array subscript 'ph::PhastaSharing[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds]
   50 |     if (isDG)
      |         ^~~~
In constructor 'ph::PhastaSharing::PhastaSharing(apf::Mesh*)',
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:101:22:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:24:39: note: object of size 16 allocated by 'operator new'
   24 |     helperN = new apf::NormalSharing(m);
      |                                       ^
In member function 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)',
    inlined from 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:51:25,
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:115:18:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:53:7: error: array subscript 'ph::PhastaSharing[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds]
   53 |       helperM->getCopies(e, copies);
      |       ^~~~~~~
In constructor 'ph::PhastaSharing::PhastaSharing(apf::Mesh*)',
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:101:22:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:24:39: note: object of size 16 allocated by 'operator new'
   24 |     helperN = new apf::NormalSharing(m);
      |                                       ^
In member function 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)',
    inlined from 'virtual void ph::PhastaSharing::getCopies(apf::MeshEntity*, apf::CopyArray&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:51:25,
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:115:18:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:51:7: error: array subscript 'ph::PhastaSharing[0]' is partly outside array bounds of 'unsigned char [16]' [-Werror=array-bounds]
   51 |       helperN->getCopies(e, copies);
      |       ^~~~~~~
In constructor 'ph::PhastaSharing::PhastaSharing(apf::Mesh*)',
    inlined from 'void ph::getLinks(apf::Mesh*, int, Links&, BCs&)' at /space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:101:22:
/space/cwsmith/pumiTestRhel9Sim/core/phasta/phLinks.cc:24:39: note: object of size 16 allocated by 'operator new'
   24 |     helperN = new apf::NormalSharing(m);
      |                                       ^
cc1plus: all warnings being treated as errors
make[2]: *** [phasta/CMakeFiles/ph.dir/build.make:135: phasta/CMakeFiles/ph.dir/phLinks.cc.o] Error 1
make[2]: Leaving directory '/space/cwsmith/pumiTestRhel9Sim/build'
make[1]: *** [CMakeFiles/Makefile2:1323: phasta/CMakeFiles/ph.dir/all] Error 2
make[1]: Leaving directory '/space/cwsmith/pumiTestRhel9Sim/build'
make: *** [Makefile:149: all] Error 2
```

## convert.cc

```
[ 62%] Building CXX object test/CMakeFiles/convert.dir/convert.cc.o
cd /space/cwsmith/pumiTestRhel9Sim/build/test && /opt/scorec/spack/rhel9/v0201_4/install/linux-rhel9-x86_64/gcc-12.3.0/mpich-4.1.1-xpoyz4tqgfxtrm6m7qq67q4ccp5pnlre/bin/mpicxx -DHAVE_CLOCK_GETTIME -DHAVE_SIMMETRIX -DOMPI_SKIP_MPICXX -DPUMI_HAS_ZOLTAN -I/space/cwsmith/pumiTestRhel9Sim/build/gmi_sim -I/space/cwsmith/pumiTestRhel9Sim/core/lion -I/space/cwsmith/pumiTestRhel9Sim/core/pcu -I/space/cwsmith/pumiTestRhel9Sim/core/pcu/reel -I/space/cwsmith/pumiTestRhel9Sim/core/gmi -I/opt/scorec/spack/rhel9/v0201_4/install/linux-rhel9-x86_64/gcc-12.3.0/simmetrix-simmodsuite-2024.0-240119dev-7abimo4wnqjk3h53clpzpb4gqljxnl2v/include -I/space/cwsmith/pumiTestRhel9Sim/core/gmi_sim -I/space/cwsmith/pumiTestRhel9Sim/core/can -I/space/cwsmith/pumiTestRhel9Sim/core/mth -I/space/cwsmith/pumiTestRhel9Sim/core/apf -I/space/cwsmith/pumiTestRhel9Sim/core/apf_sim -I/space/cwsmith/pumiTestRhel9Sim/core/mds -I/space/cwsmith/pumiTestRhel9Sim/core/parma -I/space/cwsmith/pumiTestRhel9Sim/core/zoltan -I/space/cwsmith/pumiTestRhel9Sim/core/pumi -I/space/cwsmith/pumiTestRhel9Sim/core/ma -I/space/cwsmith/pumiTestRhel9Sim/core/crv -I/space/cwsmith/pumiTestRhel9Sim/core/spr -I/space/cwsmith/pumiTestRhel9Sim/core/ree -I/space/cwsmith/pumiTestRhel9Sim/core/sam -I/space/cwsmith/pumiTestRhel9Sim/core/phasta -g -Werror -Wall -Wextra -Wno-strict-overflow  -O3 -DNDEBUG -std=gnu++11 -MD -MT test/CMakeFiles/convert.dir/convert.cc.o -MF CMakeFiles/convert.dir/convert.cc.o.d -o CMakeFiles/convert.dir/convert.cc.o -c /space/cwsmith/pumiTestRhel9Sim/core/test/convert.cc
/space/cwsmith/pumiTestRhel9Sim/core/test/convert.cc: In function 'void addFathersTag(pGModel, pParMesh, apf::Mesh*, const char*)':
/space/cwsmith/pumiTestRhel9Sim/core/test/convert.cc:360:19: error: unused variable 'exists' [-Werror=unused-variable]
  360 |         const int exists = EN_getDataPtr((pEntity)vrts[i],myFather,(void**)&fatherIdPtr);
      |                   ^~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [test/CMakeFiles/convert.dir/build.make:79: test/CMakeFiles/convert.dir/convert.cc.o] Error 1
make[2]: Leaving directory '/space/cwsmith/pumiTestRhel9Sim/build'
make[1]: *** [CMakeFiles/Makefile2:2751: test/CMakeFiles/convert.dir/all] Error 2
make[1]: Leaving directory '/space/cwsmith/pumiTestRhel9Sim/build'
make: *** [Makefile:149: all] Error 2
```