### PR TITLE
Add CTest DEPENDS property

### DIFF
--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -264,6 +264,8 @@ mpi_test(inviscid_ghost 4
   "${MDIR}/inviscid_egg.dmg"
   "${MDIR}/4/"
   "${MDIR}/vis")
+set_tests_properties(inviscid_ghost PROPERTIES DEPENDS inviscid_ugrid)
+
 set(MDIR ${MESHES}/pipe)
 if(ENABLE_SIMMETRIX)
   mpi_test(convert 1
@@ -391,6 +393,7 @@ else()
     "pipe_4_.smb"
     2)
 endif()
+set_tests_properties(split_4 PROPERTIES DEPENDS split_2)
 mpi_test(pipe_condense 4
   ./serialize
   "${MDIR}/pipe.${GXT}"
@@ -415,11 +418,16 @@ if(ENABLE_ZOLTAN)
     "${MDIR}/pipe.${GXT}"
     "pipe_4_.smb"
     "tet.smb")
+  set_tests_properties(ma_parallel tet_parallel
+    PROPERTIES DEPENDS split_4)
 endif()
 mpi_test(fieldReduce 4
   ./fieldReduce
   "${MDIR}/pipe.${GXT}"
   "pipe_4_.smb")
+set_tests_properties(pipe_condense verify_parallel fieldReduce verify_parallel
+  vtxElmMixedBalance
+  PROPERTIES DEPENDS split_4)
 
 set(MDIR ${MESHES}/torus)
 mpi_test(reorder 4
@@ -438,6 +446,7 @@ mpi_test(gap 4
   "${MDIR}/torusBal4p/"
   "1.08"
   "${MDIR}/torusOpt4p/")
+set_tests_properties(gap PROPERTIES DEPENDS balance)
 mpi_test(applyMatrixFunc 1
   ./applyMatrixFunc)
 if(ENABLE_ZOLTAN)
@@ -685,6 +694,8 @@ mpi_test(test_verify 4
   ./test_verify
   "${MDIR}/cube.dmg"
   "${MDIR}/pumi7k/4/cube.smb")
+set_tests_properties(l2_shape_tet_parallel h1_shape_parallel test_verify
+  PROPERTIES DEPENDS "construct;constructThenGhost")
 set(MDIR ${MESHES}/nonmanifold)
 mpi_test(nonmanif_verify 1
   ./verify
@@ -700,6 +711,7 @@ mpi_test(nonmanif_verify2 2
   ./verify
   "${MDIR}/nonmanifold.dmg"
   "nonmanifold_2_.smb")
+set_tests_properties(nonmanif_verify2 PROPERTIES DEPENDS nonmanif_split2)
 set(MDIR ${MESHES}/fusion)
 mpi_test(mkmodel_fusion 1
   ./mkmodel

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -772,6 +772,7 @@ if(ENABLE_SIMMETRIX)
         ./ma_test
         "${MDIR}/upright.smd"
         "67k/")
+      set_tests_properties(adapt_meshgen PROPERTIES DEPENDS parallel_meshgen)
     endif()
   endif()
   if(SIM_PARASOLID)

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -134,6 +134,7 @@ if(ENABLE_SIMMETRIX AND SIM_PARASOLID AND SIMMODSUITE_SimAdvMeshing_FOUND)
        "${MDIR}/outmesh_4_parts.sms"
        3504
        WORKING_DIRECTORY ${MDIR})
+      set_tests_properties(countBL_part_mesh PROPERTIES DEPENDS partition_sim)
     endif()
   endif()
 endif(ENABLE_SIMMETRIX AND SIM_PARASOLID AND SIMMODSUITE_SimAdvMeshing_FOUND)


### PR DESCRIPTION
- CMake test property DEPENDS has been added to the appropriate tests to facilitate parallel testing.
- Some tests require other tests to run first to operate on their output (split -> collapse, etc). Previously, tests would fail once and then succeed on a second ctest run. Now in parallel those tests wait for what they need, allowing tests to pass the first time.