### PR TITLE
Use snprintf in tests

### DIFF
--- a/parma/diffMC/maximalIndependentSet/test/testMIS.cc
+++ b/parma/diffMC/maximalIndependentSet/test/testMIS.cc
@@ -319,10 +319,10 @@ int test_2dStencil(const int rank, const int totNumParts,
   //only rank 0 will check the MIS
   int sizeIS = 0;
   char* statusMsg = new char[totNumParts * 4];
-  int pos = sprintf(statusMsg, "MIS: ");
+  int pos = snprintf(statusMsg, totNumParts * 4, "MIS: ");
   for (int i = 0; i < totNumParts; ++i) {
     if (globalIsInMIS[i]) {
-      pos += sprintf(&(statusMsg[pos]), " %d ", i);
+      pos += snprintf(&(statusMsg[pos]), totNumParts * 4 - pos, " %d ", i);
       ++sizeIS;
     }
   }
@@ -403,13 +403,13 @@ int test_StarA(const int rank, const int totNumParts,
         return 1;
       }
     }
-    sprintf(dbgMsg, " [%d] (%d) %s - adjPartIds=", 
+    snprintf(dbgMsg, 256, " [%d] (%d) %s - adjPartIds=", 
         rank, part.id, __FUNCTION__);
     Print <int, vector<int>::iterator > (cout, dbgMsg, 
         part.adjPartIds.begin(), part.adjPartIds.end(), 
         std::string(", "));
 
-    sprintf(dbgMsg, " [%d] (%d) %s - net=", 
+    snprintf(dbgMsg, 256, " [%d] (%d) %s - net=", 
         rank, part.id, __FUNCTION__);
     Print <int, vector<int>::iterator > (cout, dbgMsg, 
         part.net.begin(), part.net.end(), std::string(", "));
@@ -425,10 +425,10 @@ int test_StarA(const int rank, const int totNumParts,
     int sizeIS = 0;
     if (rank == 0) {
         char* statusMsg = new char[totNumParts * 4];
-        int pos = sprintf(statusMsg, "MIS: ");
+        int pos = snprintf(statusMsg, totNumParts * 4, "MIS: ");
         for (int i = 0; i < totNumParts; ++i) {
             if (globalIsInMIS[i]) {
-                pos += sprintf(&(statusMsg[pos]), " %d ", i);
+                pos += snprintf(&(statusMsg[pos]), totNumParts * 4 - pos, " %d ", i);
                 ++sizeIS;
             }
         }

--- a/test/convert.cc
+++ b/test/convert.cc
@@ -176,8 +176,8 @@ void addFathersTag(pGModel simModel, pParMesh sim_mesh, apf::Mesh* simApfMesh, c
 
   char coordfilename[64];
   char cnnfilename[64];
-  sprintf(coordfilename, "geom.crd");
-  sprintf(cnnfilename, "geom.cnn");
+  snprintf(coordfilename, 64, "geom.crd");
+  snprintf(cnnfilename, 64, "geom.cnn");
   FILE* fcr = fopen(coordfilename, "w");
   FILE* fcn = fopen(cnnfilename, "w");
 

--- a/test/crack_test.cc
+++ b/test/crack_test.cc
@@ -347,7 +347,7 @@ int main(int argc, char** argv)
   /* ------------------------- */
   for (int i = 2; i < 7; i++) {
     char output[256];
-    sprintf(output,"crack_curved_to_order_%d", i);
+    snprintf(output,256,"crack_curved_to_order_%d", i);
     bCurver(modelFile, "crack_linear.smb", i, output);
   }
 

--- a/test/fieldReduce.cc
+++ b/test/fieldReduce.cc
@@ -69,7 +69,7 @@ bool testReduce(apf::Mesh* m, int casenum)
     addval = myrank;
 
   char fname[256];
-  sprintf(fname, "test%d", casenum);
+  snprintf(fname, 256, "test%d", casenum);
   apf::Field* f = getTestField(m, fname, addval);
   apf::FieldShape* fshape = apf::getShape(f);
   apf::Sharing* shr = apf::getSharing(m);

--- a/test/makeAllCavities.cc
+++ b/test/makeAllCavities.cc
@@ -214,11 +214,11 @@ int main(int argc, char** argv)
       char cavityFileNameCurved[128];
       char entityFileNameLinear[128];
       char entityFileNameCurved[128];
-      sprintf(cavityFolderName, "%s_%05d", apf::Mesh::typeName[etype], index);
-      sprintf(cavityFileNameLinear, "%s", "cavity_linear");
-      sprintf(cavityFileNameCurved, "%s", "cavity_curved");
-      sprintf(entityFileNameLinear, "%s", "entity_linear");
-      sprintf(entityFileNameCurved, "%s", "entity_curved");
+      snprintf(cavityFolderName, 128, "%s_%05d", apf::Mesh::typeName[etype], index);
+      snprintf(cavityFileNameLinear, 128, "%s", "cavity_linear");
+      snprintf(cavityFileNameCurved, 128, "%s", "cavity_curved");
+      snprintf(entityFileNameLinear, 128, "%s", "entity_linear");
+      snprintf(entityFileNameCurved, 128, "%s", "entity_curved");
       writeMeshes(cavityMeshLinear, prefix, "cavities",
       	  cavityFolderName, cavityFileNameLinear, res);
       writeMeshes(cavityMeshCurved, prefix, "cavities",

--- a/test/runSimxAnisoAdapt.cc
+++ b/test/runSimxAnisoAdapt.cc
@@ -111,25 +111,25 @@ int main(int argc, char** argv)
   char outImprovedSimxMesh[256];
   char outImprovedPumiMesh[256];
 
-  sprintf(outSimxModel, "%s.smd", prefix);
-  sprintf(outInitialSimxMesh, "%s_initial.sms", prefix);
-  sprintf(outAdaptedSimxMesh, "%s_adapted.sms", prefix);
-  sprintf(outAdaptedPumiMesh, "%s_adapted.smb", prefix);
-  sprintf(outImprovedSimxMesh, "%s_adapted_improved.sms", prefix);
-  sprintf(outImprovedPumiMesh, "%s_adapted_improved.smb", prefix);
+  snprintf(outSimxModel, 256, "%s.smd", prefix);
+  snprintf(outInitialSimxMesh, 256, "%s_initial.sms", prefix);
+  snprintf(outAdaptedSimxMesh, 256, "%s_adapted.sms", prefix);
+  snprintf(outAdaptedPumiMesh, 256, "%s_adapted.smb", prefix);
+  snprintf(outImprovedSimxMesh, 256, "%s_adapted_improved.sms", prefix);
+  snprintf(outImprovedPumiMesh, 256, "%s_adapted_improved.smb", prefix);
 
   apf::Mesh2* m = apf::loadMdsMesh(inputPumiModel, inputPumiMesh);
 
   char message[512];
   // first find the sizes field
   apf::Field* sizes  = m->findField(sizeName);
-  sprintf(message, "Couldn't find a field with name %s in mesh!", sizeName);
+  snprintf(message, 512, "Couldn't find a field with name %s in mesh!", sizeName);
   PCU_ALWAYS_ASSERT_VERBOSE(sizes, message);
 
   // then find the frames field if they exist
   apf::Field* frames;
   frames  = m->findField(frameName);
-  sprintf(message, "Couldn't find a field with name %s in mesh!", frameName);
+  snprintf(message, 512, "Couldn't find a field with name %s in mesh!", frameName);
   PCU_ALWAYS_ASSERT_VERBOSE(frames, message);
 
   // remove every field except for sizes and frames

--- a/test/spr_test.cc
+++ b/test/spr_test.cc
@@ -12,7 +12,7 @@ int main(int argc, char** argv)
 {
   const char* exe = argv[0];
   char usage[1024];
-  sprintf(usage, "%s <model.dmg> <in.smb> <out-vtk> <p order>\n", exe);
+  snprintf(usage, 1024, "%s <model.dmg> <in.smb> <out-vtk> <p order>\n", exe);
   PCU_ALWAYS_ASSERT_VERBOSE(argc==5, usage);
   const char* modelFile = argv[1];
   const char* meshFile = argv[2];

--- a/test/viz.cc
+++ b/test/viz.cc
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
 
     }
     v.markPart(m,part_num);
-    snprintf(output,256,"Testing MIS %d",i);
+    snprintf(output,128,"Testing MIS %d",i);
     v.breakpoint(std::string(output));
   }
 

--- a/test/viz.cc
+++ b/test/viz.cc
@@ -47,7 +47,7 @@ int main(int argc, char** argv)
   Visualization v;
   
   char output[128];
-  sprintf(output,"%d",PCU_Comm_Self());
+  snprintf(output,128,"%d",PCU_Comm_Self());
   std::string part_num(output);
 
   apf::MeshIterator* itr;
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
 
     }
     v.markPart(m,part_num);
-    sprintf(output,"Testing MIS %d",i);
+    snprintf(output,256,"Testing MIS %d",i);
     v.breakpoint(std::string(output));
   }
 

--- a/test/xgc_split.cc
+++ b/test/xgc_split.cc
@@ -77,17 +77,17 @@ int main(int argc, char** argv)
   snprintf(without_extension,strlen(argv[3])-3,"%s",argv[3]);
 
   char vtk_fname[512];
-  sprintf(vtk_fname,"%s",without_extension); 
+  snprintf(vtk_fname,512,"%s",without_extension); 
   pumi_mesh_write(m, vtk_fname, "vtk");
 
   // ghosting
   pumi_ghost_createLayer(m, 0, 2, 3, 0);
-  sprintf(vtk_fname,"%s-ghosted",without_extension); 
+  snprintf(vtk_fname,512,"%s-ghosted",without_extension); 
   pumi_mesh_write(m, vtk_fname, "vtk");
   pumi_ghost_delete(m);
 
   pumi_ghost_createLayer(m, 0, 2, 3, 1);
-  sprintf(vtk_fname,"%s-ghosted-copy",without_extension); 
+  snprintf(vtk_fname,512,"%s-ghosted-copy",without_extension); 
   pumi_mesh_write(m, vtk_fname, "vtk");
   pumi_ghost_delete(m);
 

--- a/zoltan/apfZoltanCallbacks.cc
+++ b/zoltan/apfZoltanCallbacks.cc
@@ -313,27 +313,27 @@ void ZoltanData::setup()
   char paramStr[128];
 
   //sizes
-  sprintf(paramStr, "%u", 1);
+  snprintf(paramStr, 128, "%u", 1);
   Zoltan_Set_Param(ztn, "num_gid_entries", paramStr);
-  sprintf(paramStr, "%u", 1);
+  snprintf(paramStr, 128, "%u", 1);
   Zoltan_Set_Param(ztn, "num_lid_entries", paramStr);
 
   //weights
-  sprintf(paramStr, "%d", zb->mesh->getTagSize(zb->weights));
+  snprintf(paramStr, 128, "%d", zb->mesh->getTagSize(zb->weights));
   Zoltan_Set_Param(ztn, "obj_weight_dim", paramStr);
   Zoltan_Set_Param(ztn, "edge_weight_dim", "0");
 
   //Debug
-  sprintf(paramStr, "%d", dbgLvl);
+  snprintf(paramStr, 128, "%d", dbgLvl);
   if ( zb->isLocal && 0 != PCU_Comm_Self() )
-    sprintf(paramStr, "%d", 0);  //if local silence all but rank 0
+    snprintf(paramStr, 128, "%d", 0);  //if local silence all but rank 0
   Zoltan_Set_Param(ztn, "debug_level", paramStr);
   Zoltan_Set_Param(ztn, "PARMETIS_OUTPUT_LEVEL", paramStr);
   Zoltan_Set_Param(ztn, "CHECK_GRAPH", "0");
   Zoltan_Set_Param(ztn, "CHECK_HYPERGRAPH", "0");
 
   //tolerance
-  sprintf(paramStr, "%f", zb->tolerance);
+  snprintf(paramStr, 128, "%f", zb->tolerance);
   Zoltan_Set_Param(ztn, "imbalance_tol", paramStr);
 
   Zoltan_Set_Param(ztn, "RETURN_LISTS", "EXPORT");
@@ -343,12 +343,12 @@ void ZoltanData::setup()
 
   /* Reset some load-balancing parameters. */
   if ( zb->isLocal ) {
-    sprintf(paramStr, "%d", zb->multiple);
+    snprintf(paramStr, 128, "%d", zb->multiple);
   } else {
-    sprintf(paramStr, "%d", zb->multiple*PCU_Proc_Peers());
+    snprintf(paramStr, 128, "%d", zb->multiple*PCU_Proc_Peers());
   }
   Zoltan_Set_Param(ztn, "NUM_GLOBAL_PARTS", paramStr);
-  sprintf(paramStr, "%d", zb->multiple);
+  snprintf(paramStr, 128, "%d", zb->multiple);
   Zoltan_Set_Param(ztn, "NUM_LOCAL_PARTS", paramStr);
 
   Zoltan_Set_Param(ztn, "GRAPH_BUILD_TYPE", "FAST_NO_DUP");


### PR DESCRIPTION
- I missed some sprintf calls before. I don't see any others (find + grep).
- These deprecation errors come up with LLVM so others might not notice.