### PR TITLE
add apfElement to exported interface

### DIFF
--- a/apf/CMakeLists.txt
+++ b/apf/CMakeLists.txt
@@ -84,6 +84,7 @@ set(HEADERS
   apfField.h
   apfFieldData.h
   apfNumberingClass.h
+  apfElement.h
 )
 
 # Add the apf library


### PR DESCRIPTION
In mumfim we make direct use of the element. @maxrpi @cwsmith and @jacobmerson discussed this offline a few months ago and felt like this was a reasonable fix.
