### PR TITLE
support simmetrix simmodsuite 2024.1.240606

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -84,7 +84,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 15.0.191017)
-set(MAX_VALID_SIM_VERSION 2024.0.240219)
+set(MAX_VALID_SIM_VERSION 2024.1.240606)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")
@@ -124,10 +124,10 @@ endif()
 option(SIM_PARASOLID "Use Parasolid through Simmetrix" OFF)
 if (SIM_PARASOLID)
   set(MIN_SIM_PARASOLID_VERSION 290)
-  set(MAX_SIM_PARASOLID_VERSION 350)
+  set(MAX_SIM_PARASOLID_VERSION 361)
   foreach(version RANGE
       ${MAX_SIM_PARASOLID_VERSION}
-      ${MIN_SIM_PARASOLID_VERSION} -10)
+      ${MIN_SIM_PARASOLID_VERSION} -1)
     set(SIM_PARASOLID_VERSION ${version})
     getSimCadLib("${SIMMODSUITE_INSTALL_DIR}/lib/${SIM_ARCHOS}"
       SimParasolid${SIM_PARASOLID_VERSION} simParaLib FALSE)

--- a/test/generate.cc
+++ b/test/generate.cc
@@ -281,7 +281,6 @@ pNativeModel loadNativeModel() {
 }
 
 void simStart() {
-  SimModel_start();
   SimPartitionedMesh_start(NULL,NULL);
   if(should_log)
     Sim_logOn("generate_sim.log");

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -795,37 +795,37 @@ if(ENABLE_SIMMETRIX)
     set(MDIR ${MESHES}/curved)
     mpi_test(curvedSphere 1
       ./curvetest
-      "${MDIR}/sphere1.xmt_txt"
+      "${MDIR}/sphere1_geomSim.smd"
       "${MDIR}/sphere1_4.smb")
     mpi_test(highOrderSolutionTransfer 1
       ./highOrderSolutionTransfer
-      "${MDIR}/sphere1.xmt_txt"
+      "${MDIR}/sphere1_geomSim.smd"
       "${MDIR}/sphere1_4.smb")
     mpi_test(curvedKova 1
       ./curvetest
-      "${MDIR}/Kova.xmt_txt"
+      "${MDIR}/Kova_geomSim.smd"
       "${MDIR}/Kova.smb")
     mpi_test(degen_shpere_full 1
       ./degenerate_test
-      "${MDIR}/sph_full_nat.x_t"
+      "${MDIR}/sph_full_geomSim.smd"
       "${MDIR}/sph_full.smb"
       "sph_full_refine"
       "3")
     mpi_test(degen_shpere_no_north 1
       ./degenerate_test
-      "${MDIR}/sph_no_north_nat.x_t"
+      "${MDIR}/sph_no_north_geomSim.smd"
       "${MDIR}/sph_no_north.smb"
       "sph_no_north_refine"
       "3")
     mpi_test(degen_shpere_vertical_slice 1
       ./degenerate_test
-      "${MDIR}/sph_vertical_slice_nat.x_t"
+      "${MDIR}/sph_vertical_slice_geomSim.smd"
       "${MDIR}/sph_vertical_slice.smb"
       "sph_vertical_slice_refine"
       "3")
     mpi_test(crack_test 1
       ./crack_test
-      "${MDIR}/crack_nat.x_t")
+      "${MDIR}/crack_geomSim.smd")
   endif(SIM_PARASOLID)
 endif()
 if (PCU_COMPRESS)

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -353,7 +353,7 @@ mpi_test(tet_serial 1
 if(ENABLE_SIMMETRIX AND SIM_PARASOLID)
   mpi_test(test_residual_error_estimate 1
     ./residualErrorEstimation_test
-    "${MESHES}/electromagnetic/fichera.x_t"
+    "${MESHES}/electromagnetic/fichera_geomSim.smd"
     "${MESHES}/electromagnetic/fichera_1k.smb")
 endif()
 if(PCU_COMPRESS)


### PR DESCRIPTION
Fixes #434 and provides an approach for #438.

Used the PUMI `simTranslate` utility built with Simmetrix SimModSuite 18 to convert the parasolid and smd attribute files to a Simmetrix GeomSim model that contains both attributes, geometry, and a consistent model entity numbering.  Using the parasolid model file alone does not guarantee the model entity numbering and can/will result in failures as the mesh has model entity ids embedded in it for classification.