### PR TITLE
Fix logic checking periodic model faces

### DIFF
--- a/ma/maSnap.cc
+++ b/ma/maSnap.cc
@@ -486,7 +486,7 @@ static void interpolateParametricCoordinatesOnRegularFace(
 
   /* check if the new point is inside the model.
    * otherwise re-run the above loop with last option
-   * in "interpolateParametricCoordinae" being 1.
+   * in "interpolateParametricCoordinate" being 1.
    * Notes
    * 1) we are assuming manifold surfaces
    * 2) we only check for faces that are periodic

--- a/ma/maSnap.cc
+++ b/ma/maSnap.cc
@@ -477,8 +477,10 @@ static void interpolateParametricCoordinatesOnRegularFace(
 {
   double range[2];
   int dim = m->getModelType(g);
+  bool gface_isPeriodic = 0;
   for (int d=0; d < dim; ++d) {
     bool isPeriodic = m->getPeriodicRange(g,d,range);
+    if ((dim == 2) && (isPeriodic > 0)) gface_isPeriodic = 1;
     p[d] = interpolateParametricCoordinate(t,a[d],b[d],range,isPeriodic, 0);
   }
 
@@ -493,6 +495,8 @@ static void interpolateParametricCoordinatesOnRegularFace(
 #ifndef HAVE_CAPSTONE
   // this need to be done for faces, only
   if (dim != 2)
+    return;
+  if (!gface_isPeriodic)
     return;
 
   Vector x;


### PR DESCRIPTION
Fix bug in logic checking periodic model faces when computing parametric coordinates

This PR is relating to issue https://github.com/SCOREC/core/issues/444

The PR is correcting the logic that checks if case is periodic and then only execute the lines https://github.com/SCOREC/core/blob/60c507f0c2499b31419369683c4ddfecacc68266/ma/maSnap.cc#L502-L511 that address periodic cases