### PR TITLE
Updat doc for adaptVerbose and mark it deprecated

### DIFF
--- a/ma/ma.h
+++ b/ma/ma.h
@@ -57,12 +57,12 @@ void adapt(const Input* in);
   \details see maInput.h for details. Additional iteration(s) of refine, snap,
   and fixElementShapes are called which can lead to a different mesh than 'adapt'.
   The mesh for visualization will be written (vtk-format) at each operation stage.  */
-void adaptVerbose(Input* in, bool verbosef = false);
+void adaptVerbose(Input* in, bool verbosef = false) __attribute__((deprecated));
 /** \brief adapt verbose for debugging with unmutable configuration Input
   \details see maInput.h for details. Additional iteration(s) of refine, snap,
   and fixElementShapes are called which can lead to a different mesh than 'adapt'.
-  The mesh for visualization will be written (vtk-format) at each operation stage.  */ */
-void adaptVerbose(const Input* in, bool verbosef = false);
+  The mesh for visualization will be written (vtk-format) at each operation stage.  */
+void adaptVerbose(const Input* in, bool verbosef = false) __attribute__((deprecated));
 /** \brief run uniform refinement, plus snapping and shape correction */
 void runUniformRefinement(Mesh* m, int n=1, SolutionTransfer* s=0);
 /** \brief run uniform refinement with matched entity support

--- a/ma/ma.h
+++ b/ma/ma.h
@@ -54,12 +54,14 @@ void adapt(Input* in);
   note that this function will delete the Input object. */
 void adapt(const Input* in);
 /** \brief adapt verbose for debugging with mutable configuration Input
-  \details see maInput.h for details. The mesh will be
-  written (vtk-format) at each operation stage */
+  \details see maInput.h for details. Additional iteration(s) of refine, snap,
+  and fixElementShapes are called which can lead to a different mesh than 'adapt'.
+  The mesh for visualization will be written (vtk-format) at each operation stage.  */
 void adaptVerbose(Input* in, bool verbosef = false);
 /** \brief adapt verbose for debugging with unmutable configuration Input
-  \details see maInput.h for details. The mesh will be
-  written (vtk-format) at each operation stage */
+  \details see maInput.h for details. Additional iteration(s) of refine, snap,
+  and fixElementShapes are called which can lead to a different mesh than 'adapt'.
+  The mesh for visualization will be written (vtk-format) at each operation stage.  */ */
 void adaptVerbose(const Input* in, bool verbosef = false);
 /** \brief run uniform refinement, plus snapping and shape correction */
 void runUniformRefinement(Mesh* m, int n=1, SolutionTransfer* s=0);


### PR DESCRIPTION
There are differences in adapt and adaptVerbose function as it is now (apart from printing out the mesh and other print statements) which include additional iteration(s) of refine+snap
https://github.com/SCOREC/core/blob/8959c599cc05e21d0fb470f941d9f892da62aa02/ma/ma.cc#L106-L107  
and calling fixelementShapes Niter times
https://github.com/SCOREC/core/blob/8959c599cc05e21d0fb470f941d9f892da62aa02/ma/ma.cc#L85
This PR attempts to improve the function documentation in the header stating the above-mentioned differences and mark  function deprecated for potential upcoming name-change (breaking)