### PR TITLE
Fix unused variable warning introduced by #446

### DIFF
--- a/ma/maSnap.cc
+++ b/ma/maSnap.cc
@@ -509,6 +509,8 @@ static void interpolateParametricCoordinatesOnRegularFace(
     bool isPeriodic = m->getPeriodicRange(g,d,range);
     p[d] = interpolateParametricCoordinate(t,a[d],b[d],range,isPeriodic, 1);
   }
+#else
+  (void) gface_isPeriodic;
 #endif
 }
 


### PR DESCRIPTION
## Fix unused variable warning introduced by #446

This fixes an unused warning when CMake is given `-DENABLE_CAPSTONE` by casting to void.

However, I wonder if we can remove the `#ifndef` altogether?