### PR TITLE
Fix capstone smoothing eigen call

### DIFF
--- a/apf_cap/apfCAP.cc
+++ b/apf_cap/apfCAP.cc
@@ -1006,7 +1006,8 @@ bool smoothCAPAnisoSizes(apf::Mesh2* mesh, std::string analysis,
     apf::Matrix3x3 t(m[0], m[1], m[2],
       m[1], m[3], m[4],
       m[2], m[4], m[5]);
-    PCU_DEBUG_ASSERT(apf::eigen(t, &Q[0], &H[0]) == 3);
+    int n = apf::eigen(t, &Q[0], &H[0]);
+    PCU_DEBUG_ASSERT(n == 3);
     apf::setMatrix(frames, e, 0, Q);
     apf::setVector(scales, e, 0, H);
   }


### PR DESCRIPTION
## Fix capstone smoothing eigen call

This patch fixes an error introduced in #455 where calculations are performed in a PCU_DEBUG_ASSERT statement resulting in the exclusion of that code in Release builds.