### PR TITLE
Clarify that orthogonal basis frames are columns

### DIFF
--- a/ma/maInput.h
+++ b/ma/maInput.h
@@ -153,7 +153,7 @@ const Input* configure(
  \param sizes a vector field of desired element sizes along the
               axes of the anisotropic frame
  \param frames a matrix field containing anisotropic frames
-               for each vertex
+               for each vertex along the columns
  \param s if non-zero, use that to transfer all fields. otherwise,
           transfer any associated fields with default algorithms
  \param logInterpolation if true uses logarithmic interpolation */

--- a/ma/maSize.h
+++ b/ma/maSize.h
@@ -83,7 +83,7 @@ class AnisotropicFunction
   public:
     virtual ~AnisotropicFunction();
     /** \brief get the size field value at this vertex
-      \param r the orthonormal basis frame
+      \param r the orthonormal basis frame on each column
       \param h the desired element sizes along each
                of the frame's basis vectors */
     virtual void getValue(Entity* vert, Matrix& r, Vector& h) = 0;


### PR DESCRIPTION
- Although apf::Matrix stores rows of vectors, MeshAdapt expects basis frames on columns (as indicated by ma/maSize.cc:97). This was not made clear anywhere else. I wasted time not realizing it, so I added it explicitly in header documentation instead of buried in source code.