### PR TITLE
Fix smoothCAPAnisoSizes parameter order

### DIFF
--- a/apf_cap/apfCAP.h
+++ b/apf_cap/apfCAP.h
@@ -206,7 +206,7 @@ bool has_smoothCAPAnisoSizes(void) noexcept;
  * \pre m must be an apf::MeshCAP.
  */
 bool smoothCAPAnisoSizes(apf::Mesh2* m, std::string analysis,
-  apf::Field* frames, apf::Field* scales);
+  apf::Field* scales, apf::Field* frames);
 
 }//namespace apf
 


### PR DESCRIPTION
## Fix smoothCAPAnisoSizes parameter order

- Frames and scales were swapped in the declaration.
- The parameters have been updated in the declaration to match the definition.
  - The order scales, frames also matches the order in `ma::configure`