### PR TITLE
Support latest Simmetrix SimModSuite 2025.0 

### DIFF
--- a/cmake/FindSimModSuite.cmake
+++ b/cmake/FindSimModSuite.cmake
@@ -84,7 +84,7 @@ string(REGEX REPLACE
   "${SIM_VERSION}")
 
 set(MIN_VALID_SIM_VERSION 15.0.191017)
-set(MAX_VALID_SIM_VERSION 2024.1.240606)
+set(MAX_VALID_SIM_VERSION 2025.0.241016)
 if( ${SKIP_SIMMETRIX_VERSION_CHECK} )
   message(STATUS "Skipping Simmetrix SimModSuite version check."
     " This may result in undefined behavior")
@@ -124,7 +124,7 @@ endif()
 option(SIM_PARASOLID "Use Parasolid through Simmetrix" OFF)
 if (SIM_PARASOLID)
   set(MIN_SIM_PARASOLID_VERSION 290)
-  set(MAX_SIM_PARASOLID_VERSION 361)
+  set(MAX_SIM_PARASOLID_VERSION 370)
   foreach(version RANGE
       ${MAX_SIM_PARASOLID_VERSION}
       ${MIN_SIM_PARASOLID_VERSION} -1)


### PR DESCRIPTION
Update version numbers for the underlying parasolid and simmodsuite version.