### PR TITLE
Clean up setting of C++ standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,6 @@ include(cmake/xsdk.cmake)
 
 option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" NO)
 
-bob_set_cxx_standard(11)
-
 xsdk_begin_package()
 bob_begin_package()
 
@@ -24,7 +22,9 @@ endif()
 
 option(ENABLE_CGNS "Enable the CGNS reader: requires c++14 extensions" OFF)
 message(STATUS "ENABLE_CGNS: ${ENABLE_CGNS}")
-if(ENABLE_CGNS)
+if(NOT ENABLE_CGNS)
+  bob_set_cxx_standard(11)
+else()
   message(STATUS "enabling cxx14")
   bob_set_cxx_standard(14)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,12 +13,7 @@ include(cmake/xsdk.cmake)
 
 option(USE_XSDK_DEFAULTS "enable the XDSK v0.3.0 default configuration" NO)
 
-#requre c++11 without extensions
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSION OFF)
-if(NOT ENABLE_CGNS)
-  set(CMAKE_CXX_STANDARD 11)
-endif()
+bob_set_cxx_standard(11)
 
 xsdk_begin_package()
 bob_begin_package()
@@ -27,9 +22,12 @@ if(USE_XSDK_DEFAULTS)
   xsdk_compiler_flags()
 endif()
 
-# require c++14
 option(ENABLE_CGNS "Enable the CGNS reader: requires c++14 extensions" OFF)
 message(STATUS "ENABLE_CGNS: ${ENABLE_CGNS}")
+if(ENABLE_CGNS)
+  message(STATUS "enabling cxx14")
+  bob_set_cxx_standard(14)
+endif()
 
 # Set some default compiler flags that should always be used
 if(NOT USE_XSDK_DEFAULTS)
@@ -37,10 +35,9 @@ if(NOT USE_XSDK_DEFAULTS)
   bob_begin_cxx_flags()
   bob_end_cxx_flags()
   set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS}")
-  if(ENABLE_CGNS) #takes precedence over SCOREC_ENABLE_CXX11
-    message(STATUS "enabling cxx14")
+  if(ENABLE_CGNS)
     bob_cxx14_flags()
-  elseif(SCOREC_ENABLE_CXX11)
+  else()
     bob_cxx11_flags()
   endif()
 endif()
@@ -193,9 +190,6 @@ add_library(core INTERFACE)
 target_link_libraries(core INTERFACE ${SCOREC_EXPORTED_TARGETS})
 if(ENABLE_CGNS)
   target_link_libraries(core INTERFACE ${CMAKE_DL_LIBS}) #HDF5 uses dlopen
-  target_compile_features(core INTERFACE cxx_std_14)
-else()
-  target_compile_features(core INTERFACE cxx_std_11)
 endif()
 scorec_export_library(core)
 

--- a/cmake/bob.cmake
+++ b/cmake/bob.cmake
@@ -77,13 +77,27 @@ function(bob_begin_cxx_flags)
   set(CMAKE_CXX_FLAGS "${FLAGS}" PARENT_SCOPE)
 endfunction(bob_begin_cxx_flags)
 
+# The following is from the book,"Professional CMake: 19th edition"
+macro(bob_set_cxx_standard standard)
+  # Require C++<standard>, but let a parent project ask for something higher
+  if(DEFINED CMAKE_CXX_STANDARD)
+    if(CMAKE_CXX_STANDARD EQUAL 98 OR CMAKE_CXX_STANDARD LESS ${standard})
+      message(FATAL_ERROR "This project requires at least C++${standard}")
+    endif()
+  else()
+    set(CMAKE_CXX_STANDARD ${standard})
+  endif()
+  message(STATUS "CMAKE_CXX_STANDARD=${CMAKE_CXX_STANDARD}")
+  # Always enforce the language constraint
+  set(CMAKE_CXX_STANDARD_REQUIRED ON)
+  # We don't need compiler extensions, but let a parent ask for them
+  if(NOT DEFINED CMAKE_CXX_EXTENSIONS)
+    set(CMAKE_CXX_EXTENSIONS OFF)
+  endif()
+endmacro()
+
 function(bob_cxx11_flags)
   set(FLAGS "${CMAKE_CXX_FLAGS}")
-  if(CMAKE_CXX_COMPILER_ID MATCHES "PGI")
-    set(FLAGS "${FLAGS} -std=c++11")
-  else()
-    set(FLAGS "${FLAGS} --std=c++11")
-  endif()
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if (${PROJECT_NAME}_CXX_WARNINGS)
       set(FLAGS "${FLAGS} -Wno-c++98-compat-pedantic -Wno-c++98-compat")
@@ -94,8 +108,7 @@ endfunction(bob_cxx11_flags)
 
 function(bob_cxx14_flags)
   set(FLAGS "${CMAKE_CXX_FLAGS}")
-  # clang only: -Werror=return-stack-address -Werror=mismatched-tags
-  set(FLAGS "${FLAGS} --std=c++14 -Wall -Wextra -Wpedantic -Werror -Wno-extra-semi -Werror=unused-parameter -Wno-error=deprecated-declarations")
+  set(FLAGS "${FLAGS} -Wall -Wextra -Wpedantic -Werror -Wno-extra-semi -Werror=unused-parameter -Wno-error=deprecated-declarations")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if (${PROJECT_NAME}_CXX_WARNINGS)
       set(FLAGS "${FLAGS} -Wno-c++98-compat-pedantic -Wno-c++98-compat")


### PR DESCRIPTION
This PR adds a 'bob' cmake helper function to set the C++ standard.  The modifications do not change the default behavior of using C++11.  The user is given the ability to increase the standard to > C++11, or enable the use of extensions, by passing `CMAKE_CXX_STANDARD` and `CMAKE_CXX_EXTENSIONS`, respectively, to `cmake`.

Closes #448.