### PR TITLE
Update capstone test utils to use pcu::PCU object

### DIFF
--- a/test/capCheckParam.cc
+++ b/test/capCheckParam.cc
@@ -28,12 +28,11 @@ void checkParametrization(MeshDatabaseInterface* mdb, GeometryDatabaseInterface*
 int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
-  PCU_Comm_Init();
+  pcu::PCU *PCUobj = new pcu::PCU(MPI_COMM_WORLD);
 
   if (argc != 2) {
-    if(0==PCU_Comm_Self())
-      std::cerr << "usage: " << argv[0]
-        << " <cre file .cre>\n";
+    if (PCUobj->Self() == 0)
+      std::cerr << "usage: " << argv[0] << " <cre file .cre>\n";
     return EXIT_FAILURE;
   }
 
@@ -112,7 +111,7 @@ int main(int argc, char** argv)
   // check parametrization using capstone apis
   checkParametrization(m, g);
 
-  PCU_Comm_Free();
+  delete PCUobj;
   MPI_Finalize();
 }
 

--- a/test/capGeomTest.cc
+++ b/test/capGeomTest.cc
@@ -49,8 +49,7 @@ void visualizeEdges(gmi_model* model, int n, const char* fileName, pcu::PCU *PCU
 int main(int argc, char** argv)
 {
   MPI_Init(&argc, &argv);
-  {
-  pcu::PCU PCUObj = pcu::PCU(MPI_COMM_WORLD);
+  pcu::PCU *PCUObj = new pcu::PCU(MPI_COMM_WORLD);
 
   gmi_register_mesh();
   gmi_register_null();
@@ -118,7 +117,7 @@ int main(int argc, char** argv)
   gmi_register_cap();
 
 
-  apf::Mesh2* mesh0 = apf::createMesh(m,g,&PCUObj);
+  apf::Mesh2* mesh0 = apf::createMesh(m,g,PCUObj);
   apf::writeVtkFiles("mesh_no_param", mesh0);
 
   gmi_model* model = gmi_import_cap(g);
@@ -139,7 +138,7 @@ int main(int argc, char** argv)
   while( (ge = gmi_next(model, gi)) ){
     std::stringstream name_str;
     name_str << "face_" << gmi_tag(model, ge) << "_mesh";
-    visualizeFace(model, ge, 100, 100, name_str.str().c_str(), &PCUObj);
+    visualizeFace(model, ge, 100, 100, name_str.str().c_str(), PCUObj);
   }
   gmi_end(model, gi);
 
@@ -147,7 +146,7 @@ int main(int argc, char** argv)
   printf("creating mesh with param field\n");
 
 
-  apf::Mesh2* mesh = apf::createMesh(m,g,&PCUObj);
+  apf::Mesh2* mesh = apf::createMesh(m,g,PCUObj);
   apf::Field* pf  = apf::createFieldOn(mesh, "param_field", apf::VECTOR);
   apf::Field* idf  = apf::createFieldOn(mesh, "id", apf::SCALAR);
   apf::MeshEntity* e;
@@ -165,7 +164,7 @@ int main(int argc, char** argv)
 
   gmi_cap_stop();
 
-  }
+  delete PCUObj;
   MPI_Finalize();
 }
 
@@ -273,7 +272,7 @@ void visualizeFace(gmi_model* model, gmi_ent* entity, int n, int m, const char* 
 
   // make the vertexes and set the coordinates using the array
   std::vector<ma::Entity*> vs;
-  apf::Mesh2* mesh = apf::makeEmptyMdsMesh(gmi_load(".null"), 2, false, &PCUObj);
+  apf::Mesh2* mesh = apf::makeEmptyMdsMesh(gmi_load(".null"), 2, false, PCUObj);
   for (size_t i = 0; i < ps.size(); i++) {
     ma::Entity* vert = mesh->createVert(0);
     mesh->setPoint(vert, 0, ps[i]);

--- a/test/cap_closestPoint.cc
+++ b/test/cap_closestPoint.cc
@@ -8,7 +8,7 @@
 
 int main (int argc, char* argv[]) {
   MPI_Init(&argc, &argv);
-  PCU_Comm_Init();
+  pcu::PCU* PCUObj = new pcu::PCU(MPI_COMM_WORLD);
   lion_set_verbosity(1);
   gmi_register_cap();
 
@@ -19,7 +19,7 @@ int main (int argc, char* argv[]) {
     "Mesh Database : Create", "Attribution Database : Create");
   cs.load_files(v_string(1, creFile));
   // 2. CreateMesh.
-  apf::Mesh2* m = apf::createMesh(cs.get_mesh(), cs.get_geometry());
+  apf::Mesh2* m = apf::createMesh(cs.get_mesh(), cs.get_geometry(), PCUObj);
 
   PCU_ALWAYS_ASSERT(m->canGetClosestPoint());
 
@@ -34,6 +34,6 @@ int main (int argc, char* argv[]) {
   PCU_ALWAYS_ASSERT((to - apf::Vector3(0.5, 0.34, 0.5)).getLength() < 0.0001);
 
   apf::destroyMesh(m);
-  PCU_Comm_Free();
+  delete PCUObj;
   MPI_Finalize();
 }

--- a/test/cap_inClosureOf.cc
+++ b/test/cap_inClosureOf.cc
@@ -8,7 +8,7 @@
 
 int main (int argc, char* argv[]) {
   MPI_Init(&argc, &argv);
-  PCU_Comm_Init();
+  pcu::PCU *PCUObj = new pcu::PCU(MPI_COMM_WORLD);
   lion_set_verbosity(1);
   gmi_register_cap();
 
@@ -19,7 +19,7 @@ int main (int argc, char* argv[]) {
     "Mesh Database : Create", "Attribution Database : Create");
   cs.load_files(v_string(1, creFile));
   // 2. CreateMesh.
-  apf::Mesh2* m = apf::createMesh(cs.get_mesh(), cs.get_geometry());
+  apf::Mesh2* m = apf::createMesh(cs.get_mesh(), cs.get_geometry(), PCUObj);
   // 3. Get region 1 ModelEntity*.
   apf::ModelEntity* rgn = m->findModelEntity(3, 1);
   PCU_ALWAYS_ASSERT(rgn);
@@ -44,6 +44,6 @@ int main (int argc, char* argv[]) {
   PCU_ALWAYS_ASSERT(m->isInClosureOf(m->findModelEntity(0, 8), f1));
 
   apf::destroyMesh(m);
-  PCU_Comm_Free();
+  delete PCUObj;
   MPI_Finalize();
 }


### PR DESCRIPTION
## Update capstone test utils to use pcu::PCU object

This PR updates Capstone tests to use the new `pcu::PCU` object. Some of the tests were missed by the original PR #433 because they were moved from `capstone_clis/` into `test/`. I chose to use `new`/`delete` instead of the static object scoping because it allowed for fine-grained explicit control i.e. dropping `new pcu::PCU(MPI_COMM_WORLD)` in place of `MPI_Comm_Init()` and `delete PCUObj` in place of `MPI_Comm_Free`.

- test/capCheckParam.cc(main): replace PCU_Comm_Init with new pcu::PCU object.
- test/capGeomTest.cc(main): replace static object and scoping with dynamic new/delete (explicit scoping).
- update calls to use pointer instead of address-of static object.
- test/cap_closestPoint.cc(main): replace PCU_Comm_Init with new pcu::PCU object.
- test/cap_inClosureOf.cc(main): use new pcu::PCU object.