### PR TITLE
add ctest PROCESSORS property to aid scheduling

### DIFF
--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -6,6 +6,7 @@ function(mpi_test TESTNAME PROCS EXE)
     NAME ${TESTNAME}
     COMMAND ${MPIRUN} ${MPIRUN_PROCFLAG} ${PROCS} ${VALGRIND} ${VALGRIND_ARGS} ${EXE} ${ARGN}
   )
+  set_tests_properties(${TESTNAME} PROPERTIES PROCESSORS ${PROCS})
 endfunction(mpi_test)
 
 mpi_test(shapefun 1 ./shapefun)


### PR DESCRIPTION
## add ctest PROCESSORS property to aid scheduling

This helps speed up testing when using `ctest -j8` or the like, because the CTest scheduler can run groups of tests based on the processors they use. Without this info, it may schedule 8 tests at once, some of which actually use multiple processors.

- test/testing.cmake: add PROCESSORS property to tests created with mpi_test to help the parallel scheduler.

On trouble, I got the following results:

without PROCESSORS: `Total Test time (real) =  94.14 sec`
with PROCESSORS: `Total Test time (real) =  60.01 sec`