### PR TITLE
Remove deprecated `std::iterator`

### DIFF
--- a/pumi/pumi_list.h
+++ b/pumi/pumi_list.h
@@ -34,9 +34,14 @@ class ListMember
 };
 
 template <class T>
-class ListIterator : public std::iterator<std::forward_iterator_tag,T*>
+class ListIterator
 {
   public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T*;
+    using difference_type = std::ptrdiff_t;
+    using pointer = T**;
+    using reference = T*&;
     ListIterator():current(0) {}
     ListIterator(ListMember* p):current(p) {}
     bool operator==(ListIterator<T> const& other) const


### PR DESCRIPTION
Solved the warning related to #480 . `std::iterator` is set to be deprecated in C++17. We are expected to define the types exposed by our iterators. 
