### PR TITLE
Host the doxygen documentation through GitHub Pages

### DIFF
--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           submodules: recursive
       
-      - name: install dependencies
+      - name: Install dependencies
         run: |
               sudo apt update
               sudo apt install gcc-10 g++-10 mpich doxygen
@@ -25,12 +25,6 @@ jobs:
           MPICH_CXX: g++-10
           MPICH_CC: gcc-10
         run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_VERBOSE_MAKEFILE=ON -DMESHES=${{github.workspace}}/pumi-meshes -DIS_TESTING=ON -DSCOREC_CXX_WARNINGS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install -DSCOREC_NO_MPI=ON
-
-      - name: Build CMake
-        env:
-          MPICH_CXX: g++-10
-          MPICH_CC: gcc-10
-        run: cmake --build ${{github.workspace}}/build --config Release -j --target install
       
       - name: Generate Doc
         run: doxygen ${{github.workspace}}/build/Doxyfile

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -36,7 +36,7 @@ jobs:
         run: doxygen ${{github.workspace}}/build/Doxyfile
 
       - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./doc/html

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -9,7 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-22.04
     permissions:
-      contents: write
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,8 +31,11 @@ jobs:
       - name: Generate Doc
         run: doxygen ${{github.workspace}}/build/Doxyfile
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./doc/html
+          path: ./doc/html
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -1,0 +1,42 @@
+name: Doxygen GitHub Pages Deploy Action
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      
+      - name: install dependencies
+        run: |
+              sudo apt update
+              sudo apt install gcc-10 g++-10 mpich doxygen
+
+      - name: Configure CMake
+        env:
+          MPICH_CXX: g++-10
+          MPICH_CC: gcc-10
+        run: cmake -S ${{github.workspace}} -B ${{github.workspace}}/build -DCMAKE_CXX_COMPILER=mpicxx -DCMAKE_C_COMPILER=mpicc -DCMAKE_VERBOSE_MAKEFILE=ON -DMESHES=${{github.workspace}}/pumi-meshes -DIS_TESTING=ON -DSCOREC_CXX_WARNINGS=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install -DSCOREC_NO_MPI=ON
+
+      - name: Build CMake
+        env:
+          MPICH_CXX: g++-10
+          MPICH_CC: gcc-10
+        run: cmake --build ${{github.workspace}}/build --config Release -j --target install
+      
+      - name: Generate Doc
+        run: doxygen ${{github.workspace}}/build/Doxyfile
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/html


### PR DESCRIPTION
Create a new GitHub Actions workflow to host the doxygen documentation through GitHub Pages. The workflow should create a `gh-pages` branch (if it doesn't exist), and update it whenever changes are pushed to the master branch. GitHub Pages will then host the content from the `gh-pages` branch.

PS: We may need to manually set up the GitHub Pages in the Settings after the `gh-pages` branch is created.
