### PR TITLE
bump minimum CMake version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(DEFINED TRIBITS_PACKAGE)
 endif()
 
 # This is the top level CMake file for the SCOREC build
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 
 project(SCOREC VERSION 4.0.0 LANGUAGES CXX C)
 


### PR DESCRIPTION
## bump minimum CMake version to 3.12

- 3.12 added important list subcommands and allowed find_package to search <PackageName>_ROOT folders in a nested stack.
- it came out in 2018 so I think it is generally available to everybody by now.