### PR TITLE
Fix balancing empty parts with metis

### DIFF
--- a/metis/apfMETISbalancer.cc
+++ b/metis/apfMETISbalancer.cc
@@ -33,9 +33,9 @@ static void gatherGraph(
   std::vector<idx_t>& xadj, std::vector<idx_t>& adjncy,
   std::vector<int>& vtx_cts
 ) {
-  PCU_ALWAYS_ASSERT(PCU.Peers() > 1);
-  PCU_ALWAYS_ASSERT(owned_xadj.size() > 1);
-  PCU_ALWAYS_ASSERT(owned_adjncy.size() == size_t(owned_xadj.back()));
+  PCU_DEBUG_ASSERT(PCU.Peers() > 1);
+  PCU_DEBUG_ASSERT(!owned_xadj.empty());
+  PCU_DEBUG_ASSERT(owned_adjncy.size() == size_t(owned_xadj.back()));
   auto t0 = pcu::Time();
   int owned_vtx_ct = owned_xadj.size() - 1;
   int xadj_size = PCU.Add(owned_vtx_ct) + 1;
@@ -92,12 +92,11 @@ static void scatterPart(
   const std::vector<int>& vtx_cts,
   std::vector<idx_t>& owned_part, int n_owned
 ) {
-  PCU_ALWAYS_ASSERT(PCU.Peers() > 1);
-  PCU_ALWAYS_ASSERT(PCU.Self() != 0 || vtx_cts.size() == size_t(PCU.Peers()));
-  PCU_ALWAYS_ASSERT(
+  PCU_DEBUG_ASSERT(PCU.Peers() > 1);
+  PCU_DEBUG_ASSERT(PCU.Self() != 0 || vtx_cts.size() == size_t(PCU.Peers()));
+  PCU_DEBUG_ASSERT(
     std::accumulate(vtx_cts.begin(), vtx_cts.end(), 0UL) == part.size()
   );
-  PCU_ALWAYS_ASSERT(n_owned > 0);
   auto t0 = pcu::Time();
   owned_part.resize(n_owned);
   PCU.Begin();
@@ -171,7 +170,8 @@ static void remapPart(int nparts, std::vector<idx_t>& part, const std::vector<in
 
 void MetisBalancer::balance(MeshTag* weights, double tolerance) {
   PCU_ALWAYS_ASSERT(tolerance > 1.0);
-  if (mesh_->getPCU()->Peers() > APF_METIS_MAXRANKS) {
+  if (mesh_->getPCU()->Peers() == 1) return; // no work to be done.
+  else if (mesh_->getPCU()->Peers() > APF_METIS_MAXRANKS) {
     fail(
       "METIS called with > " STRINGIFY(APF_METIS_MAXRANKS)
       " procs, which is unsupported due to memory requirements\n"

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -112,6 +112,7 @@ if(ENABLE_ZOLTAN)
 endif()
 if(ENABLE_METIS)
   util_exe_func(mbalance mbalance.cc)
+  test_exe_func(mbalanceEmpty mbalanceEmpty.cc)
 endif()
 
 # Mesh improvement utilities

--- a/test/mbalanceEmpty.cc
+++ b/test/mbalanceEmpty.cc
@@ -41,6 +41,7 @@ int main(int argc, char* argv[]) {
     } catch (...) {
       std::throw_with_nested(std::runtime_error("balancing failed"));
     }
+    m->verify();
     m->writeNative(argv[4]);
     // destroy mds
     m->destroyNative();

--- a/test/mbalanceEmpty.cc
+++ b/test/mbalanceEmpty.cc
@@ -1,0 +1,54 @@
+#include <iostream>
+#include <exception>
+#include <memory>
+#include <string>
+#include <apf.h>
+#include <apfMDS.h>
+#include <apfMesh2.h>
+#include <apfPartition.h>
+#include <gmi_mesh.h>
+#include <apfMETIS.h>
+#include <lionPrint.h>
+#include <pcu_util.h>
+
+int main(int argc, char* argv[]) {
+  pcu::Init(&argc, &argv);
+  try {
+    pcu::PCU PCU;
+    if (argc != 5) {
+      if (PCU.Self() == 0)
+        std::cerr << "USAGE: <model.dmg> <mesh.smb> <inParts> <out.smd>"
+          << std::endl;
+      throw std::runtime_error("invalid arguments");
+    }
+    lion_set_verbosity(1);
+    gmi_register_mesh();
+    // load model and mesh
+    int inParts = std::stoi(argv[3]);
+    int group = PCU.Self() / inParts;
+    auto loadPCU = PCU.Split(group, 0);
+    gmi_model* model = gmi_load(argv[1]);
+    apf::Mesh2* m = nullptr;
+    if (group == 0) {
+      m = apf::loadMdsMesh(model, argv[2], loadPCU.get());
+      m->switchPCU(&PCU);
+    }
+    m = apf::expandMdsMesh(m, model, inParts, &PCU);
+    try {
+      std::unique_ptr<apf::Balancer> balancer(apf::makeMETISbalancer(m));
+      double imbalance = 1.1;
+      balancer->balance(nullptr, imbalance);
+    } catch (...) {
+      std::throw_with_nested(std::runtime_error("balancing failed"));
+    }
+    m->writeNative(argv[4]);
+    // destroy mds
+    m->destroyNative();
+    apf::destroyMesh(m);
+  } catch (...) {
+    pcu::Finalize();
+    return 1;
+  }
+  pcu::Finalize();
+  return 0;
+}

--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -442,6 +442,17 @@ if(ENABLE_METIS)
     3
   )
   set_test_depends(TESTS msplit_6 DEPENDS msplit_2)
+  mpi_test(mbalanceEmpty 4
+    ./mbalanceEmpty
+    "${MDIR}/pipe.dmg" "pipe.smb" 1
+    "pipe_mbe_.smb"
+  )
+  if(ENABLE_SIMMETRIX)
+    set_test_depends(
+      TESTS msplit_2 msplit_3 msplit_6 mBalanceEmpty
+      DEPENDS convert
+    )
+  endif()
 endif()
 if(ENABLE_ZOLTAN)
   mpi_test(refineX 2


### PR DESCRIPTION
## Fix balancing empty parts with metis

- added test mbalanceEmpty.cc to confirm that balancing with empty parts works.
- metis/apfMETISbalancer.cc: fixed helper function preconditions.
- (MetisBalancer::balance): allow balancing with one part (no work to do anyway).