### PR TITLE
test: fix mbalanceEmpty depends with simmetrix

### DIFF
--- a/test/testing.cmake
+++ b/test/testing.cmake
@@ -449,7 +449,7 @@ if(ENABLE_METIS)
   )
   if(ENABLE_SIMMETRIX)
     set_test_depends(
-      TESTS msplit_2 msplit_3 msplit_6 mBalanceEmpty
+      TESTS msplit_2 msplit_3 msplit_6 mbalanceEmpty
       DEPENDS convert
     )
   endif()


### PR DESCRIPTION
- test/testing.cmake: fix test name typo.