### PR TITLE
ci: remove all PR caches on close

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -13,15 +13,13 @@ jobs:
         run: |
           echo "Fetching list of cache keys"
           cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
-
-          ## Setting this to not fail the workflow while deleting cache keys.
-          set +e
-          echo "Deleting caches..."
-          for cacheKey in $cacheKeysForPR
-          do
-              gh cache delete $cacheKey
+          while [ "$cacheKeysForPR" ]; do
+            for cacheKey in $cacheKeysForPR; do
+                echo gh cache delete $cacheKey
+                gh cache delete $cacheKey
+            done
+            cacheKeysForPR=$(gh cache list --ref $BRANCH --limit 100 --json id --jq '.[].id')
           done
-          echo "Done"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}


### PR DESCRIPTION
## ci: remove all PR caches on close

The current action isn't working right (or at least isn't deleting everything).

- .github/workflows/cleanup-caches.yml: add while loop to remove caches until none are left.
- print cache ids as they are deleted