### PR TITLE
Fix cleanup-caches workflow for PRs from forks

### DIFF
--- a/.github/workflows/cleanup-caches.yml
+++ b/.github/workflows/cleanup-caches.yml
@@ -1,7 +1,7 @@
 name: Cleanup caches on closed PRs
 # From https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#matching-a-cache-key
 on:
-  pull_request:
+  pull_request_target:
     types: [ closed ]
 jobs:
   cleanup:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ if(DEFINED TRIBITS_PACKAGE)
   return()
 endif()
 
-
 # This is the top level CMake file for the SCOREC build
 cmake_minimum_required(VERSION 3.12)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ if(DEFINED TRIBITS_PACKAGE)
   return()
 endif()
 
+
 # This is the top level CMake file for the SCOREC build
 cmake_minimum_required(VERSION 3.12)
 


### PR DESCRIPTION
## Fix cleanup-caches workflow for PRs from forks

- .github/workflows/cleanup-caches.yml: change trigger type to pull_request_target which should provide a read-write token.
