### PR TITLE
add flag to explicitly link to libexecinfo

### DIFF
--- a/pcu/CMakeLists.txt
+++ b/pcu/CMakeLists.txt
@@ -46,9 +46,14 @@ add_library(pcu ${SOURCES})
 # see: https://github.com/open-mpi/ompi/issues/5157
 target_compile_definitions(pcu PUBLIC OMPI_SKIP_MPICXX)
 
-if(CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD"
-OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD" OR CMAKE_SYSTEM_NAME STREQUAL "DragonFly")
-target_link_libraries(pcu PRIVATE execinfo)
+if(
+  SCOREC_PCU_LINK_EXECINFO
+  OR CMAKE_SYSTEM_NAME STREQUAL "FreeBSD"
+  OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD"
+  OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD"
+  OR CMAKE_SYSTEM_NAME STREQUAL "DragonFly"
+)
+  target_link_libraries(pcu PRIVATE execinfo)
 endif()
 
 # Check for mallinfo, mallctl for PCU_GetMem().


### PR DESCRIPTION
## add flag to explicitly link to libexecinfo

- pcu/CMakeLists.txt: add flag to explicitly link to libexecinfo e.g. in Alpine with musl libc where libexecinfo is a 3rd party library.

Tada SCOREC/core compiles under Alpine linux (which is how I use valgrind on aarch64).