### PR TITLE
Add cxx_std_11 CMake compile feature to PCU

### DIFF
--- a/pcu/CMakeLists.txt
+++ b/pcu/CMakeLists.txt
@@ -41,6 +41,7 @@ set(HEADERS
 
 # Add the pcu library
 add_library(pcu ${SOURCES})
+target_compile_features(pcu PUBLIC cxx_std_11)
 # this compiler definition is needed to silence warnings caused by the openmpi CXX
 # bindings that are depreciated. This is needed on gcc 8 forward.
 # see: https://github.com/open-mpi/ompi/issues/5157


### PR DESCRIPTION
## Add cxx_std_11 feature to PCU

`std::unique_ptr` was introduced in C++11 and is used by the new public PCU interface.

When the C++ standard is not set with `CMAKE_CXX_STANDARD` and does not default to at least C++11 for the selected compiler, errors are emitted when other projects try to link against PUMI. The default build behavior should be successful.

This change allows the C++11 requirement to propagate to targets that link against `pcu`. The default PUMI C++ standard is already C++11:

https://github.com/SCOREC/core/blob/395d3a2e37aed9fff730cf6278d3f3f71b72d44b/CMakeLists.txt#L28-L37

This change propagates that setting outward for at least the `pcu` library (which the `core` links against, and so the library as a whole gets `cxx_std_11` as a `PUBLIC` feature).